### PR TITLE
Improve product catalogue reference & guide, plus document pagination

### DIFF
--- a/changelog/network/api.mdx
+++ b/changelog/network/api.mdx
@@ -4,15 +4,15 @@ icon: newspaper
 description: "Changelog of all major API updates, new features, removals, and improvements."
 ---
 
-<Update label="July 2025" tags={["Feature", "Catalogue"]}>
+<Update label="July 2025" tags={["Feature", "Catalog"]}>
 
-## Filtering the product catalogue by category
+## Filtering the product catalog by category
 
 We have introduced two new features to enhance how you work with product categories in the API.
 
 ### Filter products by category
 
-The [List products](/reference/2024-02-05/endpoint/products/list) endpoint now supports a `categories` query string parameter. You can use this to filter the product catalogue by one or more categories. To specify multiple categories, repeat the parameter for each category, e.g. `?categories=fashion&categories=department-stores`.
+The [List products](/reference/2024-02-05/endpoint/products/list) endpoint now supports a `categories` query string parameter. You can use this to filter the product catalog by one or more categories. To specify multiple categories, repeat the parameter for each category, e.g. `?categories=fashion&categories=department-stores`.
 
 ### List all available categories
 
@@ -22,7 +22,7 @@ Filtering needs knowledge of the available categories. You can now fetch the ful
 
 <Update label="March 2025" tags={["Feature", "Payment", "Ordering"]}>
 ## New payment payout type added
-To support the release of [Runa Pay to Card](https://runa.io/products/pay-to-card) a new payout type of `payment` has been added to the product catalogue. This new type joins the existing types of `gift_card` and `subscription`. For `payment` type products the new `payment` key will contain specific details about the product.
+To support the release of [Runa Pay to Card](https://runa.io/products/pay-to-card) a new payout type of `payment` has been added to the product catalog. This new type joins the existing types of `gift_card` and `subscription`. For `payment` type products the new `payment` key will contain specific details about the product.
 
 [Runa Pay to Card](https://runa.io/products/pay-to-card) enables you to push funds to global cards and bank accounts instantly. Funds can be sent instantly to billions of users in 190 countries, powered by Visa Direct and Mastercard. Existing customers should contact their account manager for more details.
 
@@ -49,13 +49,13 @@ For more details on our versioning strategy see the [API versioning](/best-pract
 
 </Update>
 
-<Update label="January 2025" tags={["Feature", "Catalogue", "Webhook"]}>
+<Update label="January 2025" tags={["Feature", "Catalog", "Webhook"]}>
 ## Product orderable state now supported in the Product Update webhook
 You can now receive programmatic real-time updates to the availability of products, the `is_orderable` field is now a supported field in the [Product Update webhook](/reference/2024-02-05/webhook/product.update).
 
 ### Use cases
 
-- Updating a local replica or cache of product availability. If you keep a copy of your product catalogue the availability of products could become out of sync. Using the product update webhook you can update this copy in real-time ensuring your customers don't face ordering issues for unavailable products.
+- Updating a local replica or cache of product availability. If you keep a copy of your product catalog the availability of products could become out of sync. Using the product update webhook you can update this copy in real-time ensuring your customers don't face ordering issues for unavailable products.
 - Getting live quicker with new products and products awaiting approval. The moment a product is ready for you to use the webhook will let you know.
 - Notifying your customers of the availability of products in the Runa network.
 
@@ -82,7 +82,7 @@ Check the [Product Update webhook reference](/reference/2024-02-05/webhook/produ
 
 ### Getting started with webhooks
 
-If you're not already using webhooks to receive real-time updates from Runa about the product catalogue or the state of orders you can [read about getting started here](/reference/webhooks).
+If you're not already using webhooks to receive real-time updates from Runa about the product catalog or the state of orders you can [read about getting started here](/reference/webhooks).
 
 </Update>
 

--- a/docs.json
+++ b/docs.json
@@ -91,7 +91,8 @@
                   "reference/2024-02-05/playground",
                   "reference/webhooks",
                   "reference/countries",
-                  "reference/currencies"
+                  "reference/currencies",
+                  "reference/pagination"
                 ]
               },
               {

--- a/features/limiting-available-products.mdx
+++ b/features/limiting-available-products.mdx
@@ -241,6 +241,6 @@ Here is an example of a successful response that demonstrates how the listing wi
 
 <Warning>
   **Temporarily unavailable products** We recommend to refresh your product
-  catalogue regularly because it is possible that products will be temporarily
+  catalog regularly because it is possible that products will be temporarily
   unavailable due to outages of our downstream providers.
 </Warning>

--- a/features/product-catalog.mdx
+++ b/features/product-catalog.mdx
@@ -4,32 +4,19 @@ description: "Fetch the latest catalog of products available for use in payouts"
 icon: "grid"
 ---
 
-Whether you're showing the latest product offering to your customers, or verifying constraints during your order process, you'll want the latest catalogue details.
+Whether you're showing the latest product offering to your customers, or verifying constraints during your order process, you'll want the latest catalog details.
 
-## Getting a list of countries that you can order in
+## Countries & currencies
 
-To create a payout link in the ordering process, you'll need to provide a list of products that are all redeemable in the same country. [The list of countries endpoint](/reference/2024-02-05/endpoint/products/countries) will provide you with a dynamic list with all of the countries in which you have available payout types.
+To create a payout link, you'll need to provide one or more products that are all redeemable in the same currency. See the [currencies](/reference/currencies) reference for a list of currency supported countries.
 
-This will return a list of ISO3166 ALPHA-2 country codes. We'll be modifying this list over time, so your implementation should handle the addition and removal of countries from this list.
+You may also want to limit the products you return to only those that can be redeemed in a specific country. You can fetch a list of countries using the [list countries](/reference/2024-02-05/endpoint/products/countries) endpoint. This will return a list of ISO3166 ALPHA-2 country codes. We'll be modifying this list over time, so your implementation should handle the addition and removal of countries from this list.
 
 You can use this to aggregate products that belong to a country for ordering by using the `countries_redeemable_in` query parameter, in the endpoint described below.
 
-<Card
-  title="List all countries"
-  icon="earth-europe"
-  href="/reference/2024-02-05/endpoint/products/countries"
-  horizontal
->
-  Endpoint details for listing all supported countries
-</Card>
-
 ## Retrieving your catalog
 
-We've updated our catalog to provide you with even more details than before, with improved filtering, pagination, and performance across the board.
-
-We've added new levels of granularity to payout types - differentiating between `gift_card`, `subscription`, and `payment` type products, and we'll be looking to add to these in the future. At the bottom of this page, in the Example response section, there are examples of a few permutations of responses.
-
-We recommend that you poll the [list endpoint](/reference/2024-02-05/endpoint/products/list) to retrieve full catalog details hourly and in any critical journeys where you [fetch the details of an individual product](/reference/2024-02-05/endpoint/products/get) by using the `code` query parameter to return the latest details of a product in a timely manner.
+We recommend that you query the [list endpoint](/reference/2024-02-05/endpoint/products/list) to retrieve full catalog details periodically and in any critical journeys where you [fetch the details of an individual product](/reference/2024-02-05/endpoint/products/get) by using the `code` query parameter to return the latest details of a product in a timely manner. You can also use the [product update webhook](/reference/2024-02-05/webhook/product.update) to be notified of changes to products.
 
 <CardGroup cols={2}>
   <Card
@@ -50,245 +37,152 @@ We recommend that you poll the [list endpoint](/reference/2024-02-05/endpoint/pr
   </Card>
 </CardGroup>
 
-## Field usage guidance
+## Filtering the catalog
 
-In this section, we'll detail a few of the key fields that should influence your implementation.
+You can filter by a number of fields in the list endpoint to reduce the number of products returned to only those that are relevant to your customers.
+
+| Query parameter           | Description                                                                                                                                                                     |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `is_orderable`            | When set to `true` only returns products that can be ordered. If you're presenting a list of products to your customers, you should only display products where this is `true`. |
+| `countries_redeemable_in` | Only return products that can be redeemed in a specific country, see the [countries reference](/reference/countries) for currently supported countries.                         |
+| `categories`              | Limit the products to one or more categories, see the [categories endpoint](/reference/2024-02-05/endpoint/products/categories) for a list of all current categories.           |
+
+## Important fields
+
+A few of the key fields that should influence your implementation are detailed below. For details on all fields, see the [product list endpoint](/reference/2024-02-05/endpoint/products/list) reference.
 
 ### Generic fields
 
-#### `is_orderable`
+<ResponseField name="code" type="string">
+  <Card>
+    A unique code identifying the product. Use this code when placing an order.
+  </Card>
+</ResponseField>
 
-This field indicates whether you are currently able to order a product or not. We recommend that you only ever display products to people placing orders when this field is `true` - we will reject any orders placed for products where this is `false` . You can pass this as a query parameter as part of your request.
+<ResponseField name="is_orderable" type="boolean">
+  <Card>
+    This field indicates whether you are currently able to order a product or
+    not. We recommend that you only ever display products to people placing
+    orders when this field is `true` - we will reject any orders placed for
+    products where this is `false` . You can pass this as a query parameter as
+    part of your request.
+  </Card>
+</ResponseField>
 
-#### `currency & countries_redeemable_in`
+<ResponseField name="currency" type="string">
+  <Card>
+    The currency of the product, represented by an ISO 4217 currency code. See
+    [currencies](/reference/currencies) for a list of supported currencies.
+    Orders can only be placed in one currency at a time, ensure you don't mix
+    currencies in the same order.
+  </Card>
+</ResponseField>
 
-As detailed in the Currencies section of this guide - we're constantly expanding our network to increase the payouts we can offer you and your customers. Your implementation should handle additions to these fields in their respective ISO formats.
+<ResponseField name="countries_redeemable_in" type="string[]">
+  <Card>
+    The countries in which the product can be redeemed. See the [countries
+    reference](/reference/countries) for a list of supported countries. You can
+    filter by this field to only return products that can be redeemed in a
+    specific country.
+  </Card>
+</ResponseField>
 
-#### `discount_multiplier`
+### Type specific fields
 
-The discount is represented as a decimal between 0 & 1. e.g. a discount_multiplier of 0.10 would be a 10% discount.
+There are three different payout types that you can order, each with their own specific object for details.
 
-#### `payout_type`
+- `gift_card`: A gift card is a payout that can be redeemed for a specific value.
+- `subscription`: A subscription is a payout that can be ordered for a specific duration.
+- `payment`: A payment is a payout that can be ordered for a specific value.
 
-You'll notice in the API specification that there are currently three fields, `gift_card`, `subscription`, and `payment` that are nullable and will not be present in certain responses. The `payout_type` field will indicate which of these fields is present, and your implementation should then use this key to extract the relevant required details.
+<ResponseField name="payout_type" type="string">
+  <Card>
+    You should use the `payout_type` field to determine which object to use to extract details for the product.
 
-We'll be adding more payout types in the future, and your implementation should handle these additions gracefully.
+    We'll be adding more payout types in the future, and your implementation should handle these additions gracefully.
 
-#### `categories`
+  </Card>
+</ResponseField>
 
-Used for categorizing the products.
+#### Specific `gift_card` fields
 
-Examples of values (not comprehensive): `department-stores` `home-and-diy` `toys-and-games` `supermarkets` `booksellers` `experiences` `fashion` `electricals` `entertainment` `travel` `leisure-and-sports` `food-and-drink` `beauty-and-lifestyle` `jewellers` `prepaid-card`.
+The `gift_card` object will only be present when the `payout_type` is `gift_card`.
 
-#### `content_resources`
+<ResponseField name="gift_card.denominations" type="object">
+  <Card>
+    Gift cards are either `open` or `fixed` denomination.
 
-The URL fields in this response object will contain URL's to markdown files containing their respective content. You can use this markdown and render it with your own styling as you wish.
+    - `open` products will include `minimum_value` and `maximum_value` fields. This means that you can order gift cards within the range of `minimum_value` and `maximum_value`.
+    - `fixed` products will include a list of values in the `available_list` field. You can only order values contained in the list that is returned to you.
 
-The fields will be `null` when the text has been removed, and present when added. We'll update this content semi-regularly; a `403` / `404` will be returned, should this content have been removed. Your implementation should handle this.
-
-### Gift card specific fields
-
-#### `denominations`
-
-This field will return you the constraints of values that you can order.
-
-The example responses below contain the different responses that the API can return, whether the denominations are `open` or `fixed` :
-
-- `open` products will include `minimum_value` and `maximum_value` fields. This means that you can order gift cards within the range of `minimum_value` and `maximum_value`.
-- `fixed` products will include a list of values in the `available_denominations` field. You can only order values contained in the list that is returned to you.
-
-### Subscription specific fields
-
-#### `subscription_plans`
-
-Subscriptions each come with a list of subscription plans, detailing things such as the duration of the subscription and the price it costs to order each of the subscription plans - this is without your discount applied.
-
-**subscription_plan_code** is returned as part of the subscription plan - use this code, not the top-level object code as part of your order. We'll add more subscription plans for your customers to order over time.
-
-### Payment specific fields
-
-#### `denominations`
-
-Similar to gift cards, payments have denomination constraints with `minimum_value` and `maximum_value` fields that define the allowed payment ranges, but will always be open denomination. Therefore, we don't have the list of available denominations here.
-
-## Example Response
-
-```Text JSON
-{
-    "catalog": [
-        {
-            "approval_state": "APPROVED",
-            "categories": [
-                "experiences"
-            ],
-            "code": "EXAMPLEFIXED-US",
-            "countries_redeemable_in": [
-                "US"
-            ],
-            "currency": "USD",
-            "customer_service": {
-                "phone_number": "+1 (123) 456-7890",
-                "website_url": "https:/example.com/contact"
-            },
-            "discount_multiplier": "0.1000",
-            "is_orderable": true,
-            "name": "Example Fixed Denominations US",
-            "payout_type": "gift_card",
-            "state": "LIVE",
-            "gift_card": {
-                "assets": {
-                    "card_image_url": "https:/gift.runa.io/static/product_assets/EXAMPLEFIXED-US/EXAMPLEFIXED-US-card.png",
-                    "icon_image_url": "https:/gift.runa.io/static/product_assets/EXAMPLEFIXED-US/EXAMPLEFIXED-US-icon.png",
-                    "primary_color": "#FFFFFF"
-                },
-                "balance_check_url": "https://example.com/balance-check-url",
-                "content_resources": {
-                    "description_markdown_url": "https:/catalog-service-prod-content-resource-download-bucket.s3.eu-west-1.amazonaws.com/resources/EXAMPLEFIXED-US/description.md",
-                    "disclaimer_markdown_url": "https:/catalog-service-prod-content-resource-download-bucket.s3.eu-west-1.amazonaws.com/resources/EXAMPLEFIXED-US/disclaimer.md",
-                    "locale": "en_US",
-                    "redemption_instructions_markdown_url": "https:/catalog-service-prod-content-resource-download-bucket.s3.eu-west-1.amazonaws.com/resources/EXAMPLEFIXED-US/redemption_instructions.md",
-                    "refund_policy_markdown_url": "https:/catalog-service-prod-content-resource-download-bucket.s3.eu-west-1.amazonaws.com/resources/EXAMPLEFIXED-US/refund_policy.md",
-                    "reissuance_policy_markdown_url": "https:/catalog-service-prod-content-resource-download-bucket.s3.eu-west-1.amazonaws.com/resources/EXAMPLEFIXED-US/reissuance_policy.md",
-                    "terms_buyer_markdown_url": "https:/catalog-service-prod-content-resource-download-bucket.s3.eu-west-1.amazonaws.com/resources/EXAMPLEFIXED-US/terms_buyer.md",
-                    "terms_consumer_markdown_url": "https:/catalog-service-prod-content-resource-download-bucket.s3.eu-west-1.amazonaws.com/resources/EXAMPLEFIXED-US/terms_consumer.md"
-                },
-                "denominations": {
-                    "available_list": [
-                        "0.5",
-                        "1",
-                        "5",
-                        "10",
-                        "25",
-                        "50",
-                        "100"
-                    ],
-                    "maximum_value": "100",
-                    "minimum_value": "0.5",
-                    "type": "fixed"
-                },
-                "expiry": {
-                    "date_policy": "Does not expire",
-                    "in_months": 0,
-                    "type": "indefinite"
-                },
-                "redeemable_at": "online",
-                "website_url": "https://example.com"
-            }
-        },
-        {
-            "approval_state": "APPROVED",
-            "categories": [
-                "electricals"
-            ],
-            "code": "EXAMPLEOPEN-US",
-            "countries_redeemable_in": [
-                "US"
-            ],
-            "currency": "USD",
-            "customer_service": {
-                "phone_number": "+1 (123) 456-7890",
-                "website_url": "https:/example.com/contact"
-            },
-            "discount_multiplier": "0.3",
-            "is_orderable": true,
-            "name": "Example Open Denominations US",
-            "payout_type": "gift_card",
-            "state": "TEMPORARILY_DISABLED",
-            "gift_card": {
-                "assets": {
-                    "card_image_url": "https:/gift.runa.io/static/product_assets/EXAMPLEOPEN-US/EXAMPLEOPEN-US-card.png",
-                    "icon_image_url": "https:/gift.runa.io/static/product_assets/EXAMPLEOPEN-US/EXAMPLEOPEN-US-icon.png",
-                    "primary_color": "#FFFFFF"
-                },
-                "balance_check_url": "https://example.com/balance-check-url",
-                "content_resources": {
-                    "description_markdown_url": "https:/catalog-service-prod-content-resource-download-bucket.s3.eu-west-1.amazonaws.com/resources/EXAMPLEOPEN-US/description.md",
-                    "disclaimer_markdown_url": "https:/catalog-service-prod-content-resource-download-bucket.s3.eu-west-1.amazonaws.com/resources/EXAMPLEOPEN-US/disclaimer.md",
-                    "locale": "en_US",
-                    "redemption_instructions_markdown_url": "https:/catalog-service-prod-content-resource-download-bucket.s3.eu-west-1.amazonaws.com/resources/EXAMPLEOPEN-US/redemption_instructions.md",
-                    "refund_policy_markdown_url": "https:/catalog-service-prod-content-resource-download-bucket.s3.eu-west-1.amazonaws.com/resources/EXAMPLEOPEN-US/refund_policy.md",
-                    "reissuance_policy_markdown_url": "https:/catalog-service-prod-content-resource-download-bucket.s3.eu-west-1.amazonaws.com/resources/EXAMPLEOPEN-US/reissuance_policy.md",
-                    "terms_buyer_markdown_url": "https:/catalog-service-prod-content-resource-download-bucket.s3.eu-west-1.amazonaws.com/resources/EXAMPLEOPEN-US/terms_buyer.md",
-                    "terms_consumer_markdown_url": "https:/catalog-service-prod-content-resource-download-bucket.s3.eu-west-1.amazonaws.com/resources/EXAMPLEOPEN-US/terms_consumer.md"
-                },
-                "denominations": {
-                    "available_list": null,
-                    "maximum_value": "500.00",
-                    "minimum_value": "15",
-                    "type": "open"
-                },
-                "expiry": {
-                    "date_policy": "Does not expire",
-                    "in_months": 0,
-                    "type": "indefinite"
-                },
-                "redeemable_at": "all",
-                "website_url": "https://example.com"
-            }
-        },
-        {
-            "approval_state": "APPROVED",
-            "categories": [
-                "beauty-and-fashion"
-            ],
-            "code": "SUBSCRIPTION-GB",
-            "countries_redeemable_in": [
-                "GN"
-            ],
-            "currency": "GBP",
-            "customer_service": {
-                "phone_number": "+4420 1234 5678",
-                "website_url": "https://example.com/subscription-customer-service"
-            },
-            "discount_multiplier": "0.1940",
-            "is_orderable": true,
-            "name": "Subscription Example GB",
-            "payout_type": "subscription",
-            "state": "LIVE",
-            "subscription": {
-                "assets": {
-                    "card_image_url": "https:/gift.runa.io/static/product_assets/SUBSCRIPTION-GB/SUBSCRIPTION-GB-card.png",
-                    "icon_image_url": "https:/gift.runa.io/static/product_assets/SUBSCRIPTION-GB/SUBSCRIPTION-GB-icon.png",
-                    "primary_color": "#FFFFFF"
-                },
-                "balance_check_url": "https://example.com/subscription-balance-check-url",
-                "content_resources": {
-                    "description_markdown_url": "https:/catalog-service-prod-content-resource-download-bucket.s3.eu-west-1.amazonaws.com/resources/SUBSCRIPTION-GB/description.md",
-                    "disclaimer_markdown_url": "https:/catalog-service-prod-content-resource-download-bucket.s3.eu-west-1.amazonaws.com/resources/SUBSCRIPTION-GB/disclaimer.md",
-                    "locale": "es_ES",
-                    "redemption_instructions_markdown_url": "https:/catalog-service-prod-content-resource-download-bucket.s3.eu-west-1.amazonaws.com/resources/SUBSCRIPTION-GB/redemption_instructions.md",
-                    "refund_policy_markdown_url": "https:/catalog-service-prod-content-resource-download-bucket.s3.eu-west-1.amazonaws.com/resources/SUBSCRIPTION-GB/refund_policy.md",
-                    "reissuance_policy_markdown_url": "https:/catalog-service-prod-content-resource-download-bucket.s3.eu-west-1.amazonaws.com/resources/SUBSCRIPTION-GB/reissuance_policy.md",
-                    "terms_buyer_markdown_url": "https:/catalog-service-prod-content-resource-download-bucket.s3.eu-west-1.amazonaws.com/resources/SUBSCRIPTION-GB/terms_buyer.md",
-                    "terms_consumer_markdown_url": "https:/catalog-service-prod-content-resource-download-bucket.s3.eu-west-1.amazonaws.com/resources/SUBSCRIPTION-GB/terms_consumer.md"
-                },
-                "expiry": {
-                    "date_policy": "Expires 1 year from issue date",
-                    "in_months": 12,
-                    "type": "from-issue-date"
-                },
-                "redeemable_at": "online",
-                "subscription_plans": [
-                    {
-                        "length": 6,
-                        "length_unit": "MONTHS",
-                        "name": "Subscription Example 6 months",
-                        "price": 107.94,
-                        "subscription_plan_code": "SUBSCRIPTION-GB"
-                    }
-                ],
-                "website_url": "https://example.com/subscription-details"
-            }
-        }
-    ],
-    "pagination": {
-        "cursors": {
-            "after": "After Cursor",
-            "before": "Before Cursor"
-        },
-        "page": {
-            "limit": 500
-        }
+    <CodeGroup>
+    ```json Open denomination example
+    "denominations": {
+        "type": "open",
+        "minimum_value": "5.00",
+        "maximum_value": "250.00",
+        "available_list": null
     }
-}
-```
+    ```
+
+    ```json Fixed denomination example
+    "denominations": {
+        "type": "fixed",
+        "minimum_value": "10.00",
+        "maximum_value": "100.00",
+        "available_list": ["10.00", "20.00", "50.00", "100.00"]
+    }
+    ```
+    </CodeGroup>
+
+  </Card>
+</ResponseField>
+
+#### Specific `subscription` fields
+
+The `subscription` object will only be present when the `payout_type` is `subscription`.
+
+<ResponseField name="subscription.subscription_plans" type="object[]">
+<Card>
+    Subscriptions each come with a list of subscription plans, detailing things such as the duration of the subscription and the price it costs to order each of the subscription plans – this is without your discount applied.
+
+    ```json Subscription plan example
+    {
+        "length_unit": "MONTHS",
+        "length": 3,
+        "name": "3 month subscription",
+        "price": "10.00",
+        "subscription_plan_code": "XYZ-US-SUB-1"
+    },
+    {
+        "length_unit": "MONTHS",
+        "length": 6,
+        "name": "6 month subscription",
+        "price": "20.00",
+        "subscription_plan_code": "XYZ-US-SUB-2"
+    }
+    ```
+    <Info>
+    **`subscription_plan_code`** is returned as part of the subscription plan. You must use this code, not the top-level code as part of your order.
+    </Info>
+
+  </Card>
+</ResponseField>
+
+#### Specific `payment` fields
+
+The `payment` object will only be present when the `payout_type` is `payment`.
+
+<ResponseField name="payment.denominations" type="object">
+  <Card>
+    Similar to gift cards, payments have denomination constraints with `minimum_value` and `maximum_value` fields that define the allowed payment ranges, but will always be open denomination. Therefore, we don't have the list of available denominations here.
+
+    ```json Payment denomination example
+    "denominations": {
+        "minimum_value": "5.00",
+        "maximum_value": "250.00",
+    }
+    ```
+
+  </Card>
+</ResponseField>

--- a/features/product-catalog.mdx
+++ b/features/product-catalog.mdx
@@ -24,6 +24,7 @@ We recommend that you query the [list endpoint](/reference/2024-02-05/endpoint/p
     icon="grid"
     href="/reference/2024-02-05/endpoint/products/list"
     horizontal
+    arrow
   >
     Endpoint details for listing all products, filterable by country
   </Card>
@@ -32,6 +33,7 @@ We recommend that you query the [list endpoint](/reference/2024-02-05/endpoint/p
     icon="square"
     href="/reference/2024-02-05/endpoint/products/get"
     horizontal
+    arrow
   >
     Endpoint details for getting details of a specific product by its code
   </Card>
@@ -186,3 +188,35 @@ The `payment` object will only be present when the `payout_type` is `payment`.
 
   </Card>
 </ResponseField>
+
+## Paging through the catalog
+
+The catalog is paginated, with a default page size of 500 products. You can use the `after` and `limit` query parameters to control the page size and the cursor to fetch the next page of products.
+
+```http
+GET /product?after={cursor}&limit=100
+```
+
+The response will include a `pagination` object with the following fields. You can use the `after` cursor to fetch the next page of products, and the `before` cursor to fetch the previous page of products.
+
+```json {3}
+"pagination": {
+    "cursors": {
+        "after": "MMM-US",
+        "before": "AAA-US"
+    },
+    "page": {
+        "limit": 100
+    }
+}
+```
+
+<Card
+  title="Pagination reference"
+  icon="file"
+  href="/reference/pagination"
+  horizontal
+  arrow
+>
+  More details on how pagination works in the Runa API.
+</Card>

--- a/getting-started/first-order/async.mdx
+++ b/getting-started/first-order/async.mdx
@@ -215,7 +215,7 @@ If you intend to use the async ordering mode you should take a look at the [webh
   href="/reference/webhooks"
   arrow
 >
-  Get real-time updates for the product catalogue and your orders.
+  Get real-time updates for the product catalog and your orders.
 </Card>
 
 import GettingStartedNextSteps from "/snippets/getting-started-next-steps.mdx";

--- a/reference/2024-02-05/endpoint/products/get.mdx
+++ b/reference/2024-02-05/endpoint/products/get.mdx
@@ -2,3 +2,22 @@
 title: "Get product details"
 openapi: "/reference/2024-02-05/openapi.json GET /product/{product_code}"
 ---
+
+import PayoutTypes from "/snippets/payout-types.mdx";
+
+Returns a single product by its code, e.g. `XYZ-US`.
+
+<PayoutTypes />
+
+This endpoint supports returning product content in different formats. See the [content](/reference/2024-02-05/endpoint/products/get#parameter-content) parameter for more details.
+
+<Card
+  title="Need help with the product catalog?"
+  href="/features/product-catalog"
+  icon="graduation-cap"
+  horizontal
+  arrow
+>
+  We have a guide to help you get started with the product catalog, including
+  how to filter the catalog and the different payout types.
+</Card>

--- a/reference/2024-02-05/endpoint/products/list.mdx
+++ b/reference/2024-02-05/endpoint/products/list.mdx
@@ -2,3 +2,20 @@
 title: "List products"
 openapi: "/reference/2024-02-05/openapi.json GET /product"
 ---
+
+import PayoutTypes from "/snippets/payout-types.mdx";
+
+Lists all products available for ordering in a paginated response. You can filter the products by country and category.
+
+<PayoutTypes />
+
+<Card
+  title="Need help with the product catalog?"
+  href="/features/product-catalog"
+  icon="graduation-cap"
+  horizontal
+  arrow
+>
+  We have a guide to help you get started with the product catalog, including
+  how to filter the catalog and the different payout types.
+</Card>

--- a/reference/2024-02-05/openapi.json
+++ b/reference/2024-02-05/openapi.json
@@ -368,7 +368,7 @@
                 "description": "ISO 3166 ALPHA-2 country code"
               }
             },
-            "description": "Filter by countries where a product can be redeemed in. To specify multiple countries repeat the parameter for each country, e.g. `?countries_redeemable_in=US&countries_redeemable_in=GB`"
+            "description": "Filter by countries where a product can be redeemed in. To specify multiple countries repeat the parameter for each country, e.g. `?countries_redeemable_in=US&countries_redeemable_in=GB`. You can pull the list of supported countries from the [list countries](/reference/2024-02-05/endpoint/products/countries) endpoint."
           },
           {
             "in": "query",
@@ -1269,9 +1269,7 @@
             "type": "number"
           },
           "discount_multiplier": {
-            "title": "Discount Multiplier",
-            "description": "The discount multiplier of the order item. 0 means no discount and 0.1 means 10% discount. The discount is applied on the price of the order item before any fees are applied.",
-            "type": "number"
+            "$ref": "#/components/schemas/ProductDiscountMultiplier"
           }
         },
         "description": "The computed discount for an order item."
@@ -1491,7 +1489,7 @@
         "properties": {
           "cursors": {
             "title": "Cursors",
-            "description": "Pagination cursors.",
+            "description": "Pagination cursors, use the `after` cursor to page forward and the `before` cursor to page backward.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/PageCursors"
@@ -1500,7 +1498,7 @@
           },
           "page": {
             "title": "Page",
-            "description": "Page metadata.",
+            "description": "Extra information about the current page.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/Page"
@@ -1580,10 +1578,7 @@
             "type": "string",
             "example": "0.8"
           },
-          "is_orderable": {
-            "type": "boolean",
-            "example": true
-          }
+          "is_orderable": { "$ref": "#/components/schemas/ProductIsOrderable" }
         }
       },
       "PayoutStatus": {
@@ -1681,63 +1676,157 @@
         },
         "description": "A validation error response. Returned when the request failed validation. This response can contain multiple validation errors, see the details key for each."
       },
-      "Assets": {
+      "Product": {
         "type": "object",
+        "description": "Product details",
         "properties": {
-          "card_image_url": {
+          "name": {
             "type": "string",
-            "format": "uri",
-            "nullable": true
+            "description": "The name of the product.",
+            "example": "Example Merchant"
           },
-          "icon_image_url": {
+          "code": {
             "type": "string",
-            "format": "uri",
-            "nullable": true
+            "description": "A unique code identifying the product. Use this code when placing an order. \n\n_For `subscription` products, this code identifies the top level product. You must use the `subscription_plan_code` instead when ordering._",
+            "example": "XYZ-US"
           },
-          "primary_color": {
+          "currency": {
             "type": "string",
-            "pattern": "^#[0-9A-Fa-f]{6}$",
-            "nullable": true
+            "pattern": "^[A-Z]{3}$",
+            "description": "The currency of the product, represented by an ISO 4217 currency code. See [currencies](/reference/currencies) for a list of supported currencies.",
+            "example": "USD"
+          },
+          "state": {
+            "type": "string",
+            "enum": ["LIVE", "TEMPORARILY_DISABLED", "TEMPORARILY_DEGRADED"],
+            "description": "The current state of the product.",
+            "example": "LIVE"
+          },
+          "is_orderable": { "$ref": "#/components/schemas/ProductIsOrderable" },
+          "payout_type": {
+            "type": "string",
+            "enum": ["gift_card", "subscription", "payment"],
+            "description": "The type of payout - this field will tell you the key of the additional object details that correspond to each payout type. The types currently supported are `gift_card`, `subscription`, or `payment`. Your implementation should account for additional payout types being addedin the future."
+          },
+          "categories": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of the categories that the product belongs to. You can fetch the list of categories using the [`GET /product/categories` endpoint](/reference/2024-02-05/endpoint/products/categories).",
+            "example": ["food-and-drink", "entertainment"]
+          },
+          "countries_redeemable_in": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[A-Z]{2}$",
+              "description": "ISO 3166 ALPHA-2 country code"
+            },
+            "description": "Countries where the payout can be spent.",
+            "example": ["US"]
+          },
+          "customer_service": {
+            "$ref": "#/components/schemas/ProductCustomerService"
+          },
+          "discount_multiplier": {
+            "$ref": "#/components/schemas/ProductDiscountMultiplier"
+          },
+          "availability": {
+            "type": "string",
+            "enum": ["stocked", "realtime"],
+            "description": "The availability type of the product.",
+            "example": "realtime"
+          },
+          "gift_card": {
+            "description": "Specific details about the gift card product, only populated when the `payout_type` is `gift_card`.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PayoutTypeDetailsBase"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "denominations": {
+                    "$ref": "#/components/schemas/ProductDenominations"
+                  }
+                }
+              }
+            ]
+          },
+          "subscription": {
+            "description": "Details about the subscription product, only populated when the `payout_type` is `subscription`.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PayoutTypeDetailsBase"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "subscription_plans": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ProductSubscriptionPlan"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "payment": {
+            "description": "Details about the payment product, only populated when the `payout_type` is `payment`.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProductPayment"
+              }
+            ]
           }
-        }
+        },
+        "required": [
+          "approval_state",
+          "categories",
+          "code",
+          "countries_redeemable_in",
+          "currency",
+          "customer_service",
+          "discount_multiplier",
+          "name",
+          "state",
+          "is_orderable",
+          "payout_type"
+        ]
       },
-      "BasePayoutTypeDetails": {
+      "PayoutTypeDetailsBase": {
         "type": "object",
         "properties": {
           "assets": {
-            "$ref": "#/components/schemas/Assets"
+            "$ref": "#/components/schemas/ProductAssets"
           },
           "balance_check_url": {
             "type": "string",
             "nullable": true,
             "format": "uri",
-            "description": "URL to check the gift card balance."
+            "description": "URL to check the gift card balance. This will be a provider specific URL that a consumer can use to check the balance of the gift card.",
+            "example": "https://merchant.example.com/balance-check"
           },
           "content_resources": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/ContentResources"
-              },
-              {
-                "$ref": "#/components/schemas/ContentResourcesMarkdown"
-              },
-              {
-                "$ref": "#/components/schemas/ContentResourcesHTML"
-              }
-            ]
+            "$ref": "#/components/schemas/ContentResources"
           },
           "expiry": {
-            "$ref": "#/components/schemas/Expiry"
+            "$ref": "#/components/schemas/ProductExpiry"
           },
           "redeemable_at": {
-            "description": "Defines where the gift card can be redeemed. Options are 'all' for both online and in-store, 'in-store' for in-store only, and 'online' for online only.",
+            "description": "Defines where the gift card can be redeemed. Options are `all` for both online and in-store, `in-store` for in-store only, and `online` for online only.",
             "type": "string",
-            "enum": ["all", "online", "in-store"]
+            "enum": ["all", "online", "in-store"],
+            "example": "all"
           },
           "website_url": {
+            "description": "The URL of the website for the product. This is the URL that a consumer can use to either redeem the payout or view details about where they can redeem the payout.",
             "type": "string",
             "format": "uri",
-            "nullable": true
+            "nullable": true,
+            "example": "https://merchant.example.com"
           },
           "barcode_format": {
             "type": "string",
@@ -1752,16 +1841,232 @@
               "other"
             ],
             "nullable": true,
-            "description": "The barcode format of the product."
+            "description": "The barcode format of the product.",
+            "example": "code-128"
           },
           "e_code_usage_type": {
             "type": "string",
             "enum": ["undefined", "url-recommended", "url-only"],
-            "description": "The e-code usage type of the product."
+            "description": "The e-code usage type of the product.",
+            "example": "url-only"
           }
         }
       },
+      "ProductSubscriptionPlan": {
+        "type": "object",
+        "properties": {
+          "length_unit": {
+            "description": "The unit of time for the subscription plan. Currently `DAYS` and `MONTHS` are supported.",
+            "type": "string",
+            "enum": ["DAYS", "MONTHS"],
+            "example": "MONTHS"
+          },
+          "length": {
+            "type": "integer",
+            "description": "The length of the subscription plan using the `length_unit`.",
+            "example": 12
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the subscription plan.",
+            "example": "3 month subscription"
+          },
+          "price": {
+            "type": "string",
+            "format": "decimal",
+            "description": "The price of the subscription plan.",
+            "example": "10.00"
+          },
+          "subscription_plan_code": {
+            "description": "Use this code during order creation, rather than the top level `code`.",
+            "type": "string",
+            "example": "XYZ-US-SUB-1"
+          }
+        }
+      },
+      "ProductPayment": {
+        "type": "object",
+        "properties": {
+          "assets": {
+            "type": "object",
+            "required": ["icon_image_url", "primary_color"],
+            "properties": {
+              "icon_image_url": {
+                "$ref": "#/components/schemas/ProductIconImageUrl"
+              },
+              "primary_color": {
+                "$ref": "#/components/schemas/ProductPrimaryColor"
+              }
+            }
+          },
+          "denominations": {
+            "type": "object",
+            "required": ["minimum_value", "maximum_value"],
+            "properties": {
+              "minimum_value": {
+                "$ref": "#/components/schemas/ProductMinimumValue"
+              },
+              "maximum_value": {
+                "$ref": "#/components/schemas/ProductMaximumValue"
+              }
+            }
+          },
+          "content_resources": {
+            "$ref": "#/components/schemas/ContentResources"
+          }
+        },
+        "required": ["assets", "denominations"]
+      },
+      "ProductCustomerService": {
+        "type": "object",
+        "description": "Contact information for customer service related to the product. Suitable for displaying to the customer.",
+        "properties": {
+          "phone_number": {
+            "type": "string",
+            "nullable": true,
+            "description": "The customer service phone number.",
+            "example": "+1234567890"
+          },
+          "website_url": {
+            "type": "string",
+            "nullable": true,
+            "format": "uri",
+            "description": "The customer service website URL.",
+            "example": "https://merchant.example.com/customer-service"
+          }
+        }
+      },
+      "ProductDenominations": {
+        "type": "object",
+        "description": "Defines the denomination options available for the product, including ranges and types.",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["open", "fixed"],
+            "description": "The type of denomination. Can be `open` or `fixed`. `open` is any amount between minimum and maximum value. Fixed is limited to those returned in the `available_list`."
+          },
+          "minimum_value": {
+            "$ref": "#/components/schemas/ProductMinimumValue"
+          },
+          "maximum_value": {
+            "$ref": "#/components/schemas/ProductMaximumValue"
+          },
+          "available_list": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "decimal"
+            },
+            "nullable": true,
+            "description": "A list of available denominations for the product. Will be `null` if the `type` is `OPEN`."
+          }
+        }
+      },
+      "ProductExpiry": {
+        "type": "object",
+        "properties": {
+          "date_policy": {
+            "type": "string",
+            "nullable": true,
+            "description": "Text description of the policy, suitable for displaying to the customer.",
+            "example": "Expires 2 years from issue date"
+          },
+          "in_months": {
+            "type": "integer",
+            "description": "Specifies the number of months until the gift expires.",
+            "example": 12
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of expiry policy. \n\n | Type | Description | \n | --- | --- | \n | `from-last-use` | The expiration period starts after the gift is used for a purchase. | \n | `from-last-balance-check` | The expiration period starts after the gift balance is checked using phone or online tools. | \n | `from-issue-date` | The expiration period starts from the date the gift was purchased. | \n | `indefinite` | The gift card does not expire and remains valid indefinitely. | \n | `do-not-show` | No expiration information is displayed. |",
+            "enum": [
+              "from-last-use",
+              "from-last-balance-check",
+              "from-issue-date",
+              "indefinite",
+              "do-not-show"
+            ],
+            "example": "from-issue-date"
+          }
+        }
+      },
+      "ProductIsOrderable": {
+        "type": "boolean",
+        "description": "Indicates whether or not you are able to order the product. You should use this detail to determine whether or not to display the product to your end users."
+      },
+      "ProductDiscountMultiplier": {
+        "type": "string",
+        "pattern": "^[0-9]+\\.[0-9]{2}$",
+        "description": "The discount multiplier used when ordering. `0` means no discount and `0.1` means 10% discount. The discount is applied on the price of the order item before any fees are applied.",
+        "example": "0.05"
+      },
+      "ProductMinimumValue": {
+        "type": "string",
+        "format": "decimal",
+        "description": "The minimum denomination value available for the product.",
+        "example": "10.00"
+      },
+      "ProductMaximumValue": {
+        "type": "string",
+        "format": "decimal",
+        "description": "The maximum denomination value available for the product.",
+        "example": "100.00"
+      },
+      "ProductIconImageUrl": {
+        "type": "string",
+        "format": "uri",
+        "description": "The URL of the icon image for the product.",
+        "example": "https://gift.runa.io/static/product_assets/XYZ-US/XYZ-US-icon.png"
+      },
+      "ProductPrimaryColor": {
+        "type": "string",
+        "pattern": "^#[0-9A-Fa-f]{6}$",
+        "description": "The primary color of the product.",
+        "example": "#000000"
+      },
+      "ProductAssets": {
+        "title": "Product assets",
+        "description": "Graphical assets for the product, including card image, icon image, and primary color.",
+        "type": "object",
+        "properties": {
+          "card_image_url": {
+            "type": "string",
+            "format": "uri",
+            "nullable": true,
+            "example": "https://gift.runa.io/static/product_assets/XYZ-US/XYZ-US-card.png"
+          },
+          "icon_image_url": {
+            "type": "string",
+            "format": "uri",
+            "nullable": true,
+            "example": "https://gift.runa.io/static/product_assets/XYZ-US/XYZ-US-icon.png"
+          },
+          "primary_color": {
+            "type": "string",
+            "pattern": "^#[0-9A-Fa-f]{6}$",
+            "nullable": true,
+            "example": "#000000"
+          }
+        }
+      },
+      "ContentResourcesLocale": {
+        "type": "string",
+        "description": "What locale the content resources are in. This is an [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag) using an underscore to separate the language and country codes.",
+        "pattern": "^[a-z]{2}_[A-Z]{2}$",
+        "example": "en_US"
+      },
       "ContentResources": {
+        "title": "Content resources",
+        "description": "Content resources for the product. Includes description, disclaimer, refund policy, reissuance policy, terms and conditions, redemption instructions. The content resources can be provided in a number of formats. The format returned is determined by the [`content` query string parameter](/reference/2024-02-05/endpoint/products/get#parameter-content). For the list endpoint the only content format supported is `url`.",
+        "oneOf": [
+          { "$ref": "#/components/schemas/ContentResourcesUrl" },
+          { "$ref": "#/components/schemas/ContentResourcesMarkdown" },
+          { "$ref": "#/components/schemas/ContentResourcesHTML" }
+        ]
+      },
+      "ContentResourcesUrl": {
+        "title": "URL",
+        "description": "Content resources in URL format.",
         "type": "object",
         "required": [
           "description_markdown_url",
@@ -1778,51 +2083,57 @@
             "type": "string",
             "format": "uri",
             "nullable": false,
-            "description": "A URL pointing to a markdown file that contains the description of the resource."
+            "description": "A URL pointing to a markdown file that contains the description of the resource.",
+            "example": "https://d2abcdef.cloudfront.net/resources/XYZ-US/description.md"
           },
           "disclaimer_markdown_url": {
             "type": "string",
             "format": "uri",
             "nullable": true,
-            "description": "A URL pointing to a markdown file that contains the disclaimer information."
+            "description": "A URL pointing to a markdown file that contains the disclaimer information.",
+            "example": "https://d2abcdef.cloudfront.net/resources/XYZ-US/disclaimer_markdown.md"
           },
           "refund_policy_markdown_url": {
             "type": "string",
             "format": "uri",
             "nullable": true,
-            "description": "A URL pointing to a markdown file that outlines the refund policy, if applicable."
+            "description": "A URL pointing to a markdown file that outlines the refund policy, if applicable.",
+            "example": "https://d2abcdef.cloudfront.net/resources/XYZ-US/refund_policy_markdown.md"
           },
           "reissuance_policy_markdown_url": {
             "type": "string",
             "format": "uri",
             "nullable": true,
-            "description": "A URL pointing to a markdown file that details the reissuance policy for the resource."
+            "description": "A URL pointing to a markdown file that details the reissuance policy for the resource.",
+            "example": "https://d2abcdef.cloudfront.net/resources/XYZ-US/reissuance_policy_markdown.md"
           },
           "terms_buyer_markdown_url": {
             "type": "string",
             "format": "uri",
             "nullable": true,
-            "description": "A URL pointing to a markdown file that contains the terms and conditions applicable to buyers."
+            "description": "A URL pointing to a markdown file that contains the terms and conditions applicable to buyers.",
+            "example": "https://d2abcdef.cloudfront.net/resources/XYZ-US/terms_buyer.md"
           },
           "terms_consumer_markdown_url": {
             "type": "string",
             "format": "uri",
             "nullable": true,
-            "description": "A URL pointing to a markdown file that contains the terms and conditions applicable to consumers."
+            "description": "A URL pointing to a markdown file that contains the terms and conditions applicable to consumers.",
+            "example": "https://d2abcdef.cloudfront.net/resources/XYZ-US/terms_consumer.md"
           },
           "redemption_instructions_markdown_url": {
             "type": "string",
             "format": "uri",
             "nullable": true,
-            "description": "A URL pointing to a markdown file that provides instructions for redeeming the resource."
+            "description": "A URL pointing to a markdown file that provides instructions for redeeming the resource.",
+            "example": "https://d2abcdef.cloudfront.net/resources/XYZ-US/redeem_markdown.md"
           },
-          "locale": {
-            "type": "string",
-            "description": "ISO2 format locale code. It denotes what locale the markdown urls are."
-          }
+          "locale": { "$ref": "#/components/schemas/ContentResourcesLocale" }
         }
       },
       "ContentResourcesMarkdown": {
+        "title": "Markdown",
+        "description": "Content resources in Markdown format.",
         "type": "object",
         "required": [
           "description_md",
@@ -1870,13 +2181,12 @@
             "nullable": true,
             "description": "Markdown instructions for redeeming the resource."
           },
-          "locale": {
-            "type": "string",
-            "description": "Locale code for the markdown content, in ISO2 format."
-          }
+          "locale": { "$ref": "#/components/schemas/ContentResourcesLocale" }
         }
       },
       "ContentResourcesHTML": {
+        "title": "HTML",
+        "description": "Content resources in HTML format.",
         "type": "object",
         "required": [
           "description_html",
@@ -1931,286 +2241,8 @@
             "nullable": true,
             "description": "HTML instructions for redeeming the resource."
           },
-          "locale": {
-            "type": "string",
-            "description": "Locale code for the HTML content, in ISO2 format."
-          }
+          "locale": { "$ref": "#/components/schemas/ContentResourcesLocale" }
         }
-      },
-      "CustomerService": {
-        "type": "object",
-        "description": "Contact information for customer service related to the product.",
-        "properties": {
-          "phone_number": {
-            "type": "string",
-            "nullable": true,
-            "description": "The customer service phone number."
-          },
-          "website_url": {
-            "type": "string",
-            "nullable": true,
-            "format": "uri",
-            "description": "The customer service website URL."
-          }
-        }
-      },
-      "Denominations": {
-        "type": "object",
-        "description": "Defines the denomination options available for the product, including ranges and types.",
-        "properties": {
-          "available_list": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "decimal"
-            },
-            "nullable": true,
-            "description": "A list of available denominations for the product. Null if `type` is `OPEN`."
-          },
-          "maximum_value": {
-            "type": "string",
-            "format": "decimal",
-            "description": "The maximum denomination value available for the product."
-          },
-          "minimum_value": {
-            "type": "string",
-            "format": "decimal",
-            "description": "The minimum denomination value available for the product."
-          },
-          "type": {
-            "type": "string",
-            "enum": ["open", "fixed"],
-            "description": "The type of denomination. Can be open or fixed. Open is Any amount between min and max value. Fixed is limited to those returned in the available_list."
-          }
-        }
-      },
-      "Expiry": {
-        "type": "object",
-        "properties": {
-          "date_policy": {
-            "type": "string",
-            "nullable": true,
-            "description": "Text description of the policy."
-          },
-          "in_months": {
-            "type": "integer",
-            "description": "Specifies the number of months until the gift expires."
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "from-last-use",
-              "from-last-balance-check",
-              "from-issue-date",
-              "indefinite",
-              "do-not-show"
-            ],
-            "x-enumDescriptions": {
-              "from-last-use": "The expiration period starts after the gift is used for a purchase.",
-              "from-last-balance-check": "The expiration period starts after the gift balance is checked using phone or online tools.",
-              "from-issue-date": "The expiration period starts from the date the gift was purchased.",
-              "indefinite": "The gift card does not expire and remains valid indefinitely.",
-              "do-not-show": "No expiration information is displayed."
-            }
-          }
-        }
-      },
-      "SubscriptionPlan": {
-        "type": "object",
-        "properties": {
-          "length_unit": {
-            "description": "The unit of time for the subscription plan. Currently only DAYS and MONTHS are supported.",
-            "type": "string",
-            "enum": ["DAYS", "MONTHS"]
-          },
-          "length": {
-            "type": "integer"
-          },
-          "name": {
-            "type": "string"
-          },
-          "price": {
-            "type": "string",
-            "format": "decimal"
-          },
-          "subscription_plan_code": {
-            "description": "Use this code during order creation, rather than the top level code that is part of Product.",
-            "type": "string"
-          }
-        }
-      },
-      "Product": {
-        "type": "object",
-        "description": "Base schema for all product types, containing common fields.",
-        "properties": {
-          "approval_state": {
-            "type": "string",
-            "enum": [
-              "REQUIRES_CUSTOMER_ACTION",
-              "INFORMATION_REQUESTED",
-              "PENDING",
-              "APPROVED",
-              "DENIED"
-            ],
-            "description": "Indicates weather product should be enabled for a customer based on customer supplied data. Currently only returning `APPROVED` products."
-          },
-          "categories": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "List of the categories that the product belongs to. You can fetch the list of categories using the [`GET /product/categories` endpoint](/reference/2024-02-05/endpoint/products/categories)."
-          },
-          "code": {
-            "type": "string",
-            "description": "A unique code identifying the product. You can filter for a specific product using this code, or use it for order creation - see SubscriptionPlan for more details on ordering subscription products."
-          },
-          "countries_redeemable_in": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "pattern": "^[A-Z]{2}$",
-              "description": "ISO 3166 ALPHA-2 country code"
-            },
-            "description": "Countries where the payout can be spent."
-          },
-          "currency": {
-            "type": "string",
-            "pattern": "^[A-Z]{3}$",
-            "description": "The currency of the product, represented by ISO 4217 currency codes. Please check the currency section in the guidelines for how to use this field."
-          },
-          "customer_service": {
-            "$ref": "#/components/schemas/CustomerService"
-          },
-          "discount_multiplier": {
-            "type": "string",
-            "description": "A multiplier used to calculate the price of your order."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the product."
-          },
-          "state": {
-            "type": "string",
-            "enum": ["LIVE", "TEMPORARILY_DISABLED", "TEMPORARILY_DEGRADED"],
-            "description": "The current state of the product."
-          },
-          "is_orderable": {
-            "type": "boolean",
-            "description": "Indicates whether or not you are able to order the product. You should use this detail to determine whether or not to display the product to your end users."
-          },
-          "payout_type": {
-            "type": "string",
-            "description": "The type of payout - this field will tell you the key of the additional object details that correspond to each payout type. It can be either `gift_card`, `subscription`, or `payment` for now, however, it will be extended to more types in the future, your implementation should account for it. Please check the Payout Type section in the guidelines for how to use this field."
-          },
-          "availability": {
-            "type": "string",
-            "enum": ["stocked", "realtime"],
-            "description": "The availability type of the product."
-          },
-          "gift_card": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BasePayoutTypeDetails"
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "denominations": {
-                    "$ref": "#/components/schemas/Denominations"
-                  }
-                }
-              }
-            ]
-          },
-          "subscription": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BasePayoutTypeDetails"
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "subscription_plans": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/SubscriptionPlan"
-                    }
-                  }
-                }
-              }
-            ]
-          },
-          "payment": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Payment"
-              }
-            ]
-          }
-        },
-        "required": [
-          "approval_state",
-          "categories",
-          "code",
-          "countries_redeemable_in",
-          "currency",
-          "customer_service",
-          "discount_multiplier",
-          "name",
-          "state",
-          "is_orderable",
-          "payout_type"
-        ]
-      },
-      "Payment": {
-        "type": "object",
-        "properties": {
-          "assets": {
-            "type": "object",
-            "required": ["icon_image_url", "primary_color"],
-            "properties": {
-              "icon_image_url": {
-                "type": "string",
-                "format": "uri"
-              },
-              "primary_color": {
-                "type": "string",
-                "pattern": "^#[0-9A-Fa-f]{6}$"
-              }
-            }
-          },
-          "denominations": {
-            "type": "object",
-            "required": ["minimum_value", "maximum_value"],
-            "properties": {
-              "maximum_value": {
-                "type": "string",
-                "format": "decimal",
-                "description": "The maximum denomination value available for the product."
-              },
-              "minimum_value": {
-                "type": "string",
-                "format": "decimal",
-                "description": "The minimum denomination value available for the product."
-              }
-            }
-          },
-          "content_resources": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/ContentResources"
-              },
-              {
-                "$ref": "#/components/schemas/ContentResourcesMarkdown"
-              },
-              {
-                "$ref": "#/components/schemas/ContentResourcesHTML"
-              }
-            ]
-          }
-        },
-        "required": ["assets", "denominations"]
       }
     },
     "responses": {

--- a/reference/2024-02-05/openapi.json
+++ b/reference/2024-02-05/openapi.json
@@ -447,7 +447,7 @@
             "name": "content",
             "in": "query",
             "required": false,
-            "description": "Defines the format for product content resources. It accepts 'url' (default), 'md', or 'html' to return URLs, raw Markdown, or HTML content, respectively.",
+            "description": "Defines the format for product content resources.\n\n- `url` _(default)_ for external URLs to markdown content\n- `md` for Markdown content in the response\n- `html` for rendered HTML in the response",
             "schema": {
               "type": "string",
               "enum": ["url", "md", "html"],

--- a/reference/2024-02-05/openapi.json
+++ b/reference/2024-02-05/openapi.json
@@ -1764,6 +1764,7 @@
                 "type": "object",
                 "properties": {
                   "subscription_plans": {
+                    "description": "A list of subscription plans available for the product. You must use the `subscription_plan_code` when ordering a subscription plan, not the top-level `code`.",
                     "type": "array",
                     "items": {
                       "$ref": "#/components/schemas/ProductSubscriptionPlan"
@@ -1992,7 +1993,7 @@
       },
       "ProductIsOrderable": {
         "type": "boolean",
-        "description": "Indicates whether or not you are able to order the product. You should use this detail to determine whether or not to display the product to your end users."
+        "description": "Indicates whether or not you are able to order the product. You should use this detail to determine whether or not to display the product to your end users.\n\nWe recommend that you only display products to customers when this field is `true` - we will reject any orders placed for products where this is `false`. You can filter by `is_orderable` to only return products that can be ordered in the list endpoint."
       },
       "ProductDiscountMultiplier": {
         "type": "string",
@@ -2057,7 +2058,7 @@
       },
       "ContentResources": {
         "title": "Content resources",
-        "description": "Content resources for the product. Includes description, disclaimer, refund policy, reissuance policy, terms and conditions, redemption instructions. The content resources can be provided in a number of formats. The format returned is determined by the [`content` query string parameter](/reference/2024-02-05/endpoint/products/get#parameter-content). For the list endpoint the only content format supported is `url`.",
+        "description": "Content resources provide additional information about the product, including:\n\n- Product description\n- Disclaimers\n- Refund policy\n- Reissuance policy \n- Terms and conditions\n- Redemption instructions\n\nThis content can be returned in different formats based on the `content` query parameter in the [get product endpoint](/reference/2024-02-05/endpoint/products/get#parameter-content). The list endpoint only supports returning content as URLs.\n\nContent fields will be present when content is available, and `null` when content has been removed. We update content periodically - if content has been removed, requests will return a `403` or `404` error. Your implementation should handle these errors gracefully.",
         "oneOf": [
           { "$ref": "#/components/schemas/ContentResourcesUrl" },
           { "$ref": "#/components/schemas/ContentResourcesMarkdown" },

--- a/reference/2024-02-05/openapi.json
+++ b/reference/2024-02-05/openapi.json
@@ -662,7 +662,7 @@
         "in": "query",
         "schema": {
           "type": "string",
-          "example": "ABCaa"
+          "example": "A-123"
         }
       },
       "AfterCursor": {
@@ -671,7 +671,7 @@
         "in": "query",
         "schema": {
           "type": "string",
-          "example": "ZXYzz"
+          "example": "A-789"
         }
       }
     },
@@ -1462,13 +1462,13 @@
           "after": {
             "title": "After",
             "description": "Cursor to query the next page.",
-            "example": "ZXYzz",
+            "example": "A-789",
             "type": "string"
           },
           "before": {
             "title": "Before",
             "description": "Cursor to query the previous page.",
-            "example": "ABCaa",
+            "example": "A-123",
             "type": "string"
           }
         }

--- a/reference/2024-02-05/openapi.json
+++ b/reference/2024-02-05/openapi.json
@@ -351,14 +351,6 @@
           },
           {
             "in": "query",
-            "name": "code",
-            "schema": {
-              "type": "string"
-            },
-            "description": "Filter by product code"
-          },
-          {
-            "in": "query",
             "name": "countries_redeemable_in",
             "schema": {
               "type": "array",
@@ -1784,7 +1776,6 @@
           }
         },
         "required": [
-          "approval_state",
           "categories",
           "code",
           "countries_redeemable_in",

--- a/reference/2024-02-05/openapi.json
+++ b/reference/2024-02-05/openapi.json
@@ -401,7 +401,7 @@
           {
             "in": "query",
             "name": "after",
-            "description": "A cursor for use in pagination to return the next set of products. The before and after cursors are mutually exclusive (you can't use them at the same time).",
+            "description": "A cursor for use in pagination to return the next set of products. The before and after cursors are mutually exclusive (you can't use them at the same time). See [pagination](/reference/pagination) for more information on how to use this parameter.",
             "schema": {
               "type": "string"
             }
@@ -409,7 +409,7 @@
           {
             "in": "query",
             "name": "before",
-            "description": "A cursor for use in pagination to return the previous set of products. The before and after cursors are mutually exclusive (you can't use them at the same time).",
+            "description": "A cursor for use in pagination to return the previous set of products. The before and after cursors are mutually exclusive (you can't use them at the same time). See [pagination](/reference/pagination) for more information on how to use this parameter.",
             "schema": {
               "type": "string"
             }
@@ -417,7 +417,7 @@
           {
             "in": "query",
             "name": "limit",
-            "description": "A limit on the number of items to be returned.",
+            "description": "A limit on the number of items to be returned. See [pagination](/reference/pagination) for more information on how to use this parameter.",
             "schema": {
               "type": "integer",
               "default": 500,
@@ -1499,6 +1499,7 @@
         "title": "PageableMeta",
         "required": ["cursors", "page"],
         "type": "object",
+        "description": "Information about the page of results returned. See [pagination](/reference/pagination) for more information on how to page through results.",
         "properties": {
           "cursors": {
             "title": "Cursors",

--- a/reference/2024-02-05/openapi.json
+++ b/reference/2024-02-05/openapi.json
@@ -137,24 +137,8 @@
             "in": "query",
             "description": "The number (1&ndash;500) of orders to include in each page of orders. Default: 100."
           },
-          {
-            "required": false,
-            "name": "before",
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "description": "A cursor. Using this parameter will return the page of orders from *before* the cursor (i.e., the _previous_ page). The `before` and `after` cursors are mutually exclusive (you can't use them at the same time). Get this value from the `pagination` section of any page of orders."
-          },
-          {
-            "required": false,
-            "name": "after",
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "description": "A cursor. Using this parameter will return the page of orders from *after* the cursor (i.e., the _next_ page). The `before` and `after` cursors are mutually exclusive (you can't use them at the same time). Get this value from the `pagination` section of any page of orders."
-          }
+          { "$ref": "#/components/parameters/BeforeCursor" },
+          { "$ref": "#/components/parameters/AfterCursor" }
         ],
         "responses": {
           "200": {
@@ -398,22 +382,8 @@
             },
             "description": "Filter by product categories. To specify multiple categories repeat the parameter for each category, e.g. `?categories=fashion&categories=department-stores`. You can pull the list of categories from the [list categories](/reference/2024-02-05/endpoint/products/categories) endpoint."
           },
-          {
-            "in": "query",
-            "name": "after",
-            "description": "A cursor for use in pagination to return the next set of products. The before and after cursors are mutually exclusive (you can't use them at the same time). See [pagination](/reference/pagination) for more information on how to use this parameter.",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "before",
-            "description": "A cursor for use in pagination to return the previous set of products. The before and after cursors are mutually exclusive (you can't use them at the same time). See [pagination](/reference/pagination) for more information on how to use this parameter.",
-            "schema": {
-              "type": "string"
-            }
-          },
+          { "$ref": "#/components/parameters/BeforeCursor" },
+          { "$ref": "#/components/parameters/AfterCursor" },
           {
             "in": "query",
             "name": "limit",
@@ -693,6 +663,24 @@
         "description": "The currency of the account, represented by ISO 4217 currency codes. Check the [currencies](/reference/currency) for a listing of supported currencies.",
         "in": "query",
         "example": "USD"
+      },
+      "BeforeCursor": {
+        "name": "before",
+        "description": "A cursor for use in pagination to return the previous set of results. The before and after cursors are mutually exclusive (you can't use them at the same time). You can get a value from the `pagination.cursors.before` field in the response. See [pagination](/reference/pagination) for more information.",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "example": "ABCaa"
+        }
+      },
+      "AfterCursor": {
+        "name": "after",
+        "description": "A cursor for use in pagination to return the next set of results. The before and after cursors are mutually exclusive (you can't use them at the same time). You can get a value from the `pagination.cursors.after` field in the response. See [pagination](/reference/pagination) for more information.",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "example": "ZXYzz"
+        }
       }
     },
     "schemas": {
@@ -1484,13 +1472,13 @@
           "after": {
             "title": "After",
             "description": "Cursor to query the next page.",
-            "example": "ZXhhbXBsZW9mYWN1cnNvcg==",
+            "example": "ZXYzz",
             "type": "string"
           },
           "before": {
             "title": "Before",
             "description": "Cursor to query the previous page.",
-            "example": "ZXhhbXBsZW9mYWN1cnNvcg==",
+            "example": "ABCaa",
             "type": "string"
           }
         }

--- a/reference/2024-02-05/openapi.json
+++ b/reference/2024-02-05/openapi.json
@@ -1959,7 +1959,8 @@
               "format": "decimal"
             },
             "nullable": true,
-            "description": "A list of available denominations for the product. Will be `null` if the `type` is `OPEN`."
+            "description": "A list of available denominations for the product. Will be `null` if the `type` is `OPEN`.",
+            "example": ["10.00", "20.00", "50.00", "100.00"]
           }
         }
       },

--- a/reference/2024-02-05/playground.mdx
+++ b/reference/2024-02-05/playground.mdx
@@ -72,7 +72,7 @@ You can use the following curated template IDs in the `products` field while cre
 <Accordion title="List products">
   The [List Products endpoint](/reference/2024-02-05/endpoint/products/list) lets you retrieve a list of products you can create orders for.
 
-This catalog of produsts in playground is static and corresponds to our base product selection without additional product approval. You may have access to a broader range of products when using the production API. You can only place Playground orders with the products returned from this endpoint.
+This catalog of products in playground is static and corresponds to our base product selection without additional product approval. You may have access to a broader range of products when using the production API. You can only place Playground orders with the products returned from this endpoint.
 
 </Accordion>
 <Accordion title="Get a list of countries where products are available">

--- a/reference/2024-02-05/playground.mdx
+++ b/reference/2024-02-05/playground.mdx
@@ -72,7 +72,7 @@ You can use the following curated template IDs in the `products` field while cre
 <Accordion title="List products">
   The [List Products endpoint](/reference/2024-02-05/endpoint/products/list) lets you retrieve a list of products you can create orders for.
 
-This catalogue of produsts in playground is static and corresponds to our base product selection without additional product approval. You may have access to a broader range of products when using the production API. You can only place Playground orders with the products returned from this endpoint.
+This catalog of produsts in playground is static and corresponds to our base product selection without additional product approval. You may have access to a broader range of products when using the production API. You can only place Playground orders with the products returned from this endpoint.
 
 </Accordion>
 <Accordion title="Get a list of countries where products are available">

--- a/reference/2024-02-05/webhook/product.update.mdx
+++ b/reference/2024-02-05/webhook/product.update.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Product update"
-description: "Product update events are triggered when there is an update to the catalogue."
+description: "Product update events are triggered when there is an update to the catalog."
 openapi: "/reference/2024-02-05/openapi.json WEBHOOK product.update"
 ---
 
@@ -15,7 +15,7 @@ openapi: "/reference/2024-02-05/openapi.json WEBHOOK product.update"
   understand how they work.
 </Card>
 
-An event is triggered when there is an update to a product in the catalogue. If multiple products are updated at once, an event is triggered for each product.
+An event is triggered when there is an update to a product in the catalog. If multiple products are updated at once, an event is triggered for each product.
 
 Use the `product_code` to identify the product that was updated, then refer to the `old_state` and `new_state` to determine the changes. A `timestamp` is provided to indicate when the update occurred.
 

--- a/reference/pagination.mdx
+++ b/reference/pagination.mdx
@@ -13,8 +13,8 @@ A `pagination` object is returned for paged endpoints, use the `after` cursor to
 ```json Pagination object in a response {3}
 "pagination": {
     "cursors": {
-        "after": "ZXYzz",
-        "before": "ABCaa"
+        "after": "A-789",
+        "before": "A-123"
     },
     "page": {
         "limit": 100
@@ -22,7 +22,7 @@ A `pagination` object is returned for paged endpoints, use the `after` cursor to
 }
 ```
 
-For the above response you would add `?after=ZXYzz` to the request to get the next page of results.
+For the above response you would add `?after=A-789` to the request to get the next page of results.
 
 ## Detecting the end of the results
 
@@ -30,7 +30,7 @@ The `after` cursor is always returned in the response if there are results in th
 
 ## Paging backwards
 
-You can page in reverse by using the `before` cursor. For example you would `?before=ABCaa` to the request to get the previous page of results.
+You can page in reverse by using the `before` cursor. For example you would `?before=A-123` to the request to get the previous page of results.
 
 ## Controlling the number of records returned
 

--- a/reference/pagination.mdx
+++ b/reference/pagination.mdx
@@ -1,0 +1,37 @@
+---
+title: "Pagination"
+icon: "file"
+description: "Handling endpoints that return multiple pages of data"
+---
+
+Some Runa API endpoints split large sets of results into multiple pages. We return an array of records and a token to get the next page of data. The tokens are cursor-based rather than page numbers to prevent missing or duplicating returned records if new items are added to the set while you're paging through the results.
+
+## Paging through results
+
+A `pagination` object is returned for paged endpoints, use the `after` cursor to get the next page of results.
+
+```json Pagination object in a response {3}
+"pagination": {
+    "cursors": {
+        "after": "ZXYzz",
+        "before": "ABCaa"
+    },
+    "page": {
+        "limit": 100
+    }
+}
+```
+
+For the above response you would add `?after=ZXYzz` to the request to get the next page of results.
+
+## Detecting the end of the results
+
+The `after` cursor is always returned in the response if there are results in the current page. There are no more results if you receive an empty data array in the response.
+
+## Paging backwards
+
+You can page in reverse by using the `before` cursor. For example you would `?before=ABCaa` to the request to get the previous page of results.
+
+## Controlling the number of records returned
+
+Some endpoints support a `limit` parameter to control the number of records returned. The default page size is documented in the endpoint's reference.

--- a/reference/webhooks.mdx
+++ b/reference/webhooks.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Webhooks"
-description: "Real-time updates for the product catalogue and your orders."
+description: "Real-time updates for the product catalog and your orders."
 icon: "webhook"
 ---
 
@@ -44,7 +44,7 @@ We currently support the following webhook events:
     href="/reference/2024-02-05/webhook/product.update"
     arrow
   >
-    The `product.update` webhook is triggered when a product in the catalogue is
+    The `product.update` webhook is triggered when a product in the catalog is
     updated.
   </Card>
 </Columns>

--- a/snippets/payout-types.mdx
+++ b/snippets/payout-types.mdx
@@ -1,0 +1,7 @@
+This endpoint returns different payout types:
+
+- `gift_card`: A gift card is a payout that can be redeemed for a specific value.
+- `subscription`: A subscription is a payout that can be ordered for a specific duration.
+- `payment`: A payment is a payout that can be ordered for a specific value.
+
+You should use the `payout_type` field to determine which object to use to extract details for the product. The different payout types have different fields, so you should use the appropriate object to extract the details you need.


### PR DESCRIPTION
- [x] Document pagination in new reference page
- [x] Improve examples in product list reference
- [x] Redraft the product list guide, include filtering by category
- [ ] Payout type page?

# Changes

- A pretty big refactor of the spec for product endpoints
    - I've extracted common repeated fields into shared schemas
    - I've added examples so the response shown in the docs looks half-sensible
    - I've updated or added descriptions to the fields so reading through the reference is enough if you know what you're doing, the guide is an optional 'getting started' point now
    - I've **removed** `approval_state` from the docs, it appears pointless given we're only returning `APPROVED` products. We can re-add later if needed.
    - I've **removed** the `code` query from the list endpoint docs, given we have the get endpoint this param appears redundant and confusing.
- Rewrite the product catalog feature guide. Instead of trying to cover everything this is just enough information to get you started using the catalogue.
    - Change the start where it says products need to be same country to currency
    - Add section about filtering
    - Reduce important fields to just the important ones
    - Add section about pagination
- Rename `catalogue` to `catalog` :britishcry:
- Add a new 'pagination' page to explain how pagination works across our whole API