### PR TITLE
Add denomination support documentation to product.update webhook

### DIFF
--- a/reference/2024-02-05/webhook/product.update.mdx
+++ b/reference/2024-02-05/webhook/product.update.mdx
@@ -24,3 +24,54 @@ Use the `product_code` to identify the product that was updated, then refer to t
   You should store the `timestamp` and discard any events that are older than
   the last event you received.
 </Info>
+
+## Denomination Structure
+
+The `denominations` object within both `old_state` and `new_state` represents the available purchase amounts for a product. It has the following structure:
+
+### Properties
+
+- `type` - The denomination type, either:
+  - `"fixed"` - Product has predetermined fixed denominations
+  - `"open"` - Product accepts any amount within specified range
+
+- `available_list` - Array of strings representing available denomination amounts (only for `"fixed"` type)
+
+- `minimum_value` - String representing the minimum purchase amount (only for `"open"` type)
+
+- `maximum_value` - String representing the maximum purchase amount (only for `"open"` type)
+
+### Usage Examples
+
+#### Fixed Denominations
+```json
+{
+  "denominations": {
+    "type": "fixed",
+    "available_list": ["10", "25", "50", "100"]
+  }
+}
+```
+
+#### Open Denominations
+```json
+{
+  "denominations": {
+    "type": "open",
+    "minimum_value": "5",
+    "maximum_value": "500"
+  }
+}
+```
+
+#### Product Becomes Non-Orderable
+```json
+{
+  "denominations": {
+    "type": "fixed",
+    "available_list": []
+  }
+}
+```
+
+When a product becomes non-orderable (`is_orderable: false`), the `denominations.available_list` will be empty for fixed denomination products.

--- a/reference/2024-02-05/webhook/product.update.mdx
+++ b/reference/2024-02-05/webhook/product.update.mdx
@@ -69,9 +69,9 @@ The `denominations` object within both `old_state` and `new_state` represents th
 {
   "denominations": {
     "type": "fixed",
-    "available_list": []
+    "available_list": ["10", "25", "50"]
   }
 }
 ```
 
-When a product becomes non-orderable (`is_orderable: false`), the `denominations.available_list` will be empty for fixed denomination products.
+When a product becomes non-orderable (`is_orderable: false`), the `denominations.available_list` continues to contain the same denomination values that were available when the product was orderable. The denomination information is preserved regardless of the product's orderability status.

--- a/reference/2024-02-05/webhook/product.update.mdx
+++ b/reference/2024-02-05/webhook/product.update.mdx
@@ -74,4 +74,4 @@ The `denominations` object within both `old_state` and `new_state` represents th
 }
 ```
 
-When a product becomes non-orderable (`is_orderable: false`), the `denominations.available_list` continues to contain the same denomination values that were available when the product was orderable. The denomination information is preserved regardless of the product's orderability status.
+When a product becomes non-orderable (`is_orderable: false`), the `denominations.available_list` continues to contain the same denomination values that were available when the product was orderable.


### PR DESCRIPTION
Description:
  ## Summary
  - Added comprehensive documentation for the new `denominations` structure in product.update webhook events
  - Documented fixed vs open denomination types with clear examples
  - Explained behavior when products become non-orderable

  ## Changes
  - Updated `/reference/2024-02-05/webhook/product.update.mdx` with denomination structure documentation
  - Added usage examples for fixed denominations, open denominations, and non-orderable states
  - Clarified the relationship between `is_orderable` and `denominations.available_list`

  ## Context
  Relates to MXP-2825 denomination support implementation in the webhook service.
