### PR TITLE
EFX support in the order-estimate endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ pnpm dev
 A local server will then serve the docs at http://localhost:3000
 Hot-reload is supported
 
+⚠️ Note: If you get an error similar to `Error: Could not load the "sharp" module using the darwin-arm64 runtime`, try installing the pre-built arm64 package like so:
+
+```bash
+pnpm add @img/sharp-darwin-arm64 --force
+```
+
+and then run `pnpm dev`.
+
 ## Mintlify
 
 See [Mintlify docs](https://mintlify.com/docs) for more information. The `docs.json` file is the configuration file. Pages are written in MDX, a markdown variant with JSX support.

--- a/changelog/api.mdx
+++ b/changelog/api.mdx
@@ -4,6 +4,17 @@ icon: newspaper
 description: "Changelog of all major API updates, new features, removals, and improvements."
 ---
 
+<Update label="September 2025" tags={["Feature", "Embedded FX", "Ordering"]}>
+## Order Estimate now supports Embedded FX orders
+
+We are glad to announce that you can use the `POST /v2/order/estimate` endpoint to get the price estimate for an Embedded FX order.
+
+Please refer to the Order Estimate [API reference](/reference/2024-02-05/endpoint/orders/estimate) the request and response for details.
+
+More examples can also be found in the [Embedded FX guide](/features/embedded-fx).
+
+</Update>
+
 <Update label="July 2025" tags={["Feature", "Catalog"]}>
 
 ## Filtering the product catalog by category

--- a/features/embedded-fx.mdx
+++ b/features/embedded-fx.mdx
@@ -122,6 +122,76 @@ To help you understand the costs involved in making this embedded FX order, we p
 2. An exchange rate (`fx.rate`) of 1.2 was applied for converting GBP to USD. (See below for more details on how our rates work.)
 3. A `fee` of £0.16 GBP was charged for the currency conversion. This fee is included in the `total_price` of the order and is always charged in the currency specified for the `payment_method`.
 
+## Getting the price estimate for an Embedded FX order
+
+You can get an estimate of how much an Embedded FX order will cost by using the `/v2/order/estimate` endpoint. Detailed guidance on how to use it can be found in the [order estimate reference](/reference/2024-02-05/endpoint/orders/estimate).
+
+### Example
+
+Here's an example of a basic request and response for getting the estimate of an order with embedded FX.
+
+<CodeGroup>
+```json Request {4}
+{
+  "payment_method": {
+    "type": "ACCOUNT_BALANCE",
+    "currency": "GBP"
+  },
+  "items": [
+    {
+      "face_value": 10,
+      "distribution_method": {
+        "type": "EMAIL",
+        "email_address": "fred@bloggs.com"
+      },
+      "products": {
+        "type": "MULTIPLE",
+        "values": ["AMZ-US", "AMC-US"]
+      }
+    }
+  ]
+}
+```
+
+```json Response {21-33}
+{
+  "payment_method": {
+    "type": "ACCOUNT_BALANCE",
+    "currency": "GBP"
+  },
+  "currency": "GBP",
+  "total_discount": "0.00",
+  "total_price": "8.49",
+  "items": [
+    {
+      "products": {
+        "type": "MULTIPLE",
+        "values": ["AMZ-US", "AMC-US"]
+      },
+      "currency": "USD",
+      "face_value": "10.00",
+      "price": "10.00",
+      "discount_multiplier": "0.05"
+    }
+  ],
+  "transaction_detail": {
+    "USD": {
+      "value": "10.00",
+      "fx": {
+        "rate": "1.2",
+        "rate_symbol": "GBPUSD",
+        "fee": {
+          "value": "0.16",
+          "currency": "GBP"
+        }
+      }
+    }
+  }
+}
+```
+
+</CodeGroup>
+
 ## Rates and Fees
 
 ### FX Rates

--- a/features/estimate.mdx
+++ b/features/estimate.mdx
@@ -9,12 +9,6 @@ icon: calculator-simple
   environment](/reference/2024-02-05/playground).
 </Info>
 
-<Info>
-  The estimate endpoint currently does not support [Embedded
-  FX](/features/embedded-fx) orders. The currency of the payment method must be
-  the same as the currency of the order items.
-</Info>
-
 ## Order pricing
 
 The total price of an order is determined by the face value and discounts of the items you're purchasing, plus any additional fees that apply to the order.
@@ -22,11 +16,6 @@ The total price of an order is determined by the face value and discounts of the
 ## Estimate order price
 
 To provide you with a clear breakdown of the order price before you confirm your purchase the [estimate order](/reference/2024-02-05/endpoint/orders/estimate) endpoint can optionally be used to get your estimated order price including fees. It accepts a request similar to the one used for creating an order and responds with a detailed breakdown of the estimated price for both the overall order and each individual item within the order.
-
-<Note>
-  Please note that the order price estimate endpoint does **not** support
-  Embedded FX orders.
-</Note>
 
 Below is an estimate request and response for an order with 2 order items.
 

--- a/reference/2024-02-05/endpoint/orders/estimate.mdx
+++ b/reference/2024-02-05/endpoint/orders/estimate.mdx
@@ -8,9 +8,3 @@ description: "Estimate the price for the order"
   The estimate endpoint is currently **unsupported** in the [playground
   environment](/reference/2024-02-05/playground).
 </Info>
-
-<Info>
-  The estimate endpoint currently does not support [Embedded
-  FX](/features/embedded-fx) orders. The currency of the payment method must be
-  the same as the currency of the order items.
-</Info>

--- a/reference/2024-02-05/openapi.json
+++ b/reference/2024-02-05/openapi.json
@@ -1352,6 +1352,9 @@
             "title": "Total Price",
             "description": "Total price of the entire order.",
             "type": "number"
+          },
+          "transaction_detail": {
+            "$ref": "#/components/schemas/TransactionDetail"
           }
         },
         "description": "Response object for a order price estimate."

--- a/reference/2024-02-05/openapi.json
+++ b/reference/2024-02-05/openapi.json
@@ -1224,7 +1224,13 @@
       },
       "OrderItemDiscount": {
         "title": "OrderItemDiscount",
-        "required": ["products", "face_value", "price", "discount_multiplier"],
+        "required": [
+          "products",
+          "face_value",
+          "price",
+          "discount_multiplier",
+          "currency"
+        ],
         "type": "object",
         "properties": {
           "products": {
@@ -1252,6 +1258,13 @@
           },
           "discount_multiplier": {
             "$ref": "#/components/schemas/ProductDiscountMultiplier"
+          },
+          "currency": {
+            "title": "Currency",
+            "example": "USD",
+            "type": "string",
+            "pattern": "^[A-Z]{3}$",
+            "description": "The currency of the product, represented by ISO 4217 currency codes. Please check the currency section in the guidelines for how to use this field."
           }
         },
         "description": "The computed discount for an order item."


### PR DESCRIPTION
* Update API spec to include `transaction_details` in the estimate response
* Remove notes saying estimate doesn't support EFX
* Update EFX guide
* Add changelog
* Add note in ReadMe for fixing dependencies issues

⚠️ **NOTE**: Do not merge yet as the implementation of the feature is still in progress.