### PR TITLE
Document Redemption API availability in Playground

### DIFF
--- a/features/redemption-api.mdx
+++ b/features/redemption-api.mdx
@@ -11,6 +11,16 @@ icon: "code"
 
 The Redemption API allows you to retrieve raw gift card redemption details at the point where you need to display them to your customers. This gives you control over the customer journey by presenting gift card details within your own experience, rather than using the default Runa redemption page.
 
+## Availability
+
+The Redemption API is available in both the [Playground](/reference/2024-02-05/playground) and Production environments. The same feature gate applies to both — contact your Account Manager to enable it on your account before testing in Playground.
+
+In Playground, the `payout.url` returned on an order will be on the `spend.playground.runa.io` domain. Append `?format=json` to that URL just as you would in Production:
+
+```http
+GET https://spend.playground.runa.io/{payout-id}?format=json
+```
+
 ## How it works
 
 1. [Create an order](/reference/2024-02-05/endpoint/orders/create) as usual.

--- a/features/redemption-api.mdx
+++ b/features/redemption-api.mdx
@@ -15,12 +15,6 @@ The Redemption API allows you to retrieve raw gift card redemption details at th
 
 The Redemption API is available in both the [Playground](/reference/2024-02-05/playground) and Production environments. The same feature gate applies to both — contact your Account Manager to enable it on your account before testing in Playground.
 
-In Playground, the `payout.url` returned on an order will be on the `spend.playground.runa.io` domain. Append `?format=json` to that URL just as you would in Production:
-
-```http
-GET https://spend.playground.runa.io/{payout-id}?format=json
-```
-
 ## How it works
 
 1. [Create an order](/reference/2024-02-05/endpoint/orders/create) as usual.

--- a/getting-started/first-order/async.mdx
+++ b/getting-started/first-order/async.mdx
@@ -177,7 +177,7 @@ The response will be a `200 OK` with the order details in the body. You can retr
       "payout": {
         "status": "ACTIVE",
         "status_updated_at": "2025-01-01T12:00:01+00:00",
-        "url": "https://payout.playground.runa.io/01234567-0000-4000-abcd-012345678900",
+        "url": "https://spend.playground.runa.io/01234567-0000-4000-abcd-012345678900",
       },
       "currency": "USD"
     },
@@ -194,7 +194,7 @@ The response will be a `200 OK` with the order details in the body. You can retr
       "payout": {
         "status": "ACTIVE",
         "status_updated_at": "2025-01-01T12:00:01+00:00",
-        "url": "https://payout.playground.runa.io/11234567-0000-4000-abcd-012345678900",
+        "url": "https://spend.playground.runa.io/11234567-0000-4000-abcd-012345678900",
       },
       "currency": "USD"
     }

--- a/getting-started/first-order/sync.mdx
+++ b/getting-started/first-order/sync.mdx
@@ -138,7 +138,7 @@ The response will be a `200 OK` with the order details in the body. You can retr
       "payout": {
         "status": "ACTIVE",
         "status_updated_at": "2025-01-01T12:00:01+00:00",
-        "url": "https://payout.playground.runa.io/01234567-0000-4000-abcd-012345678900",
+        "url": "https://spend.playground.runa.io/01234567-0000-4000-abcd-012345678900",
       },
       "currency": "USD"
     }


### PR DESCRIPTION
Add an Availability section to the Redemption API page clarifying that the feature is available in both Playground and Production (same gate applies), and show the playground payout URL format. Also fix stale payout.playground.runa.io references in the getting-started examples.