### PR TITLE
Clarify Redemption API response shapes

### DIFF
--- a/features/redemption-api.mdx
+++ b/features/redemption-api.mdx
@@ -41,7 +41,7 @@ GET {payout.url}?format=json
 
 ## Response
 
-The top-level fields below are present on every response. The contents of `e_code` depend on the gift card `type` — see [Response shapes](#response-shapes).
+The top-level fields below are present on every response. The contents of `e_code` depend on the gift card `type` — see [`e_code` object](#e-code-object).
 
 <ResponseField name="status" type="string">
   `SUCCESS` or `ERROR`. On `ERROR`, see the top-level `error_code` and

--- a/features/redemption-api.mdx
+++ b/features/redemption-api.mdx
@@ -5,21 +5,26 @@ icon: "code"
 ---
 
 <Info>
-  The Redemption API is not available by default. To enable this feature,
-  contact your Account Manager.
+  The Redemption API is not available by default. To enable it, contact your
+  Account Manager. The same feature gate applies to both the
+  [Playground](/reference/2024-02-05/playground) and Production environments.
 </Info>
 
-The Redemption API allows you to retrieve raw gift card redemption details at the point where you need to display them to your customers. This gives you control over the customer journey by presenting gift card details within your own experience, rather than using the default Runa redemption page.
-
-## Availability
-
-The Redemption API is available in both the [Playground](/reference/2024-02-05/playground) and Production environments. The same feature gate applies to both — contact your Account Manager to enable it on your account before testing in Playground.
+The Redemption API lets you fetch raw gift card redemption details — codes, PINs, barcodes, or redemption URLs — so you can present them inside your own customer experience instead of redirecting customers to the default Runa redemption page.
 
 ## How it works
 
 1. [Create an order](/reference/2024-02-05/endpoint/orders/create) as usual.
-2. The order response contains a `url` field in the `payout` object.
-3. Append `?format=json` to the URL to retrieve the redemption details in a structured format.
+2. Read the `url` field from the `payout` object in the order response.
+3. Append `?format=json` to that URL and `GET` it to receive structured redemption data.
+
+The URL itself is the credential — it is unique per payout and grants access to that payout's redemption details. No additional API key or header is required.
+
+<Note>
+  Without `?format=json`, the URL returns the default Runa redemption web page
+  and is rate limited. The `json` format is intended for server-to-server use
+  and must be enabled by your Account Manager.
+</Note>
 
 ## Request
 
@@ -30,87 +35,234 @@ GET {payout.url}?format=json
 ### Query parameters
 
 <ParamField path="format" type="string" default="html">
-  Response format. Set to `json` to receive structured gift card data. The
-  `json` format must be enabled by your Account Manager. Rate limiting applies
-  when using `html`.
+  Set to `json` to receive structured gift card data. Omit, or set to `html`,
+  to receive the default Runa redemption page.
 </ParamField>
 
 ## Response
 
+The wrapper is the same for every successful response:
+
 <ResponseField name="status" type="string">
-  `SUCCESS` or `ERROR` If `ERROR`, check the `error_code` and `error_string`
-  fields for details. If `SUCCESS`, the gift card redemption details are in the
-  `e_code` field.
+  `SUCCESS` or `ERROR`. On `ERROR`, see the top-level `error_code` and
+  `error_string`. On `SUCCESS`, redemption details are in `e_code`.
 </ResponseField>
 
 <ResponseField name="order_id" type="string">
   Your order ID (e.g. `O-ABC123`).
 </ResponseField>
 
-<ResponseField name="e_code" type="object">
-  The gift card redemption details.
-
-  <Expandable title="child attributes">
-
-<ResponseField name="type" type="string">
-  `code` or `url` For `code` type products, gift card details are in the `code`,
-  `pin`, etc. fields. For `url` type products, redirect your customer to the
-  `url` field.
-</ResponseField>
-
-<ResponseField name="code" type="string">
-  The primary gift card code, if applicable.
-</ResponseField>
-
-<ResponseField name="pin" type="string">
-  The gift card PIN, if applicable. For `url` type products, this contains the
-  URL.
-</ResponseField>
-
-<ResponseField name="url" type="string">
-  URL where your customer can access their gift card.
-</ResponseField>
-
-<ResponseField name="amount" type="string">
-  Amount in major units as a decimal string.
-</ResponseField>
-
-<ResponseField name="expiry_date" type="string">
-  Expiry date of the gift card, if applicable. `3000-01-01` indicates the gift
-  card is valid indefinitely.
-</ResponseField>
-
-<ResponseField name="barcode_format" type="string">
-  Barcode format: `code-128`, `code-39`, `ean-13`, `QR`, or `pdf417`. Also
-  available from the [product details
-  endpoint](/reference/2024-02-05/endpoint/products/list).
-</ResponseField>
-
-<ResponseField name="barcode_string" type="string">
-  The barcode value. Encode using `barcode_format` to produce a valid barcode.
-</ResponseField>
-
 <ResponseField name="error_code" type="string">
-  Error code if the product was not retrieved.
-</ResponseField>
-
-  <ResponseField name="error_string" type="string">
-    Description of the error if the product was not retrieved.
-  </ResponseField>
-  </Expandable>
-</ResponseField>
-
-<ResponseField name="error_code" type="string">
-  Top-level error code, or `null`.
+  Top-level error code, or `null`. See [Error codes](#error-codes).
 </ResponseField>
 
 <ResponseField name="error_string" type="string">
-  Description of the error, or `null`.
+  Human-readable description of the top-level error, or `null`.
 </ResponseField>
 
 <ResponseField name="error_details" type="string">
   Additional error details, or `null`.
 </ResponseField>
+
+<ResponseField name="e_code" type="object">
+  The gift card redemption details. The populated fields depend on
+  `e_code.type` — see [Response shapes](#response-shapes) below.
+</ResponseField>
+
+## Response shapes
+
+The `e_code.type` field tells you how to render the gift card. There are three shapes in practice:
+
+| `type`   | When to use it                                 | Render as                          |
+| -------- | ---------------------------------------------- | ---------------------------------- |
+| `code`   | Plain alphanumeric code (with optional PIN)    | Display `code` (and `pin` if set)  |
+| `code`   | Barcode-backed code                            | Display `code` and render a barcode from `barcode_string` using `barcode_format` |
+| `url`    | Redemption hosted by the brand                 | Redirect the customer to `url`     |
+
+### Common `e_code` fields
+
+These fields are present on every shape:
+
+<ResponseField name="type" type="string">
+  `code` or `url`. Determines which other fields are populated.
+</ResponseField>
+
+<ResponseField name="status" type="string">
+  Mirrors the top-level `status`. Always equal to it — provided for backwards
+  compatibility.
+</ResponseField>
+
+<ResponseField name="amount" type="string">
+  Amount in major units, as a decimal string (e.g. `"50.00"`).
+</ResponseField>
+
+<ResponseField name="expiry_date" type="string">
+  Expiry date of the gift card. The sentinel value `3000-01-01` indicates the
+  gift card does not expire.
+</ResponseField>
+
+<ResponseField name="url" type="string">
+  A URL where the customer can access their gift card. Always present.
+</ResponseField>
+
+<ResponseField name="error_code" type="string">
+  Per-`e_code` error code, or `null`. See [Error codes](#error-codes).
+</ResponseField>
+
+<ResponseField name="error_string" type="string">
+  Per-`e_code` error description, or `null`.
+</ResponseField>
+
+### Shape 1 — `type: "code"`, plain code
+
+The customer redeems by entering the `code` (and `pin`, if present) at the brand. Barcode fields are `null`.
+
+<ResponseField name="code" type="string">
+  The gift card code.
+</ResponseField>
+
+<ResponseField name="pin" type="string">
+  PIN, if the brand requires one. `null` otherwise. Only present on plain-code
+  redemptions — never set alongside a barcode.
+</ResponseField>
+
+<ResponseField name="barcode_format" type="null">
+  Always `null` for this shape.
+</ResponseField>
+
+<ResponseField name="barcode_string" type="null">
+  Always `null` for this shape.
+</ResponseField>
+
+### Shape 2 — `type: "code"`, barcode
+
+The customer redeems by scanning a barcode in-store. `barcode_format` and `barcode_string` are always set together — you need the format to decode the string. `pin` is always `null` for this shape.
+
+<ResponseField name="code" type="string">
+  The gift card code (also encoded in the barcode).
+</ResponseField>
+
+<ResponseField name="barcode_format" type="string">
+  One of `code-128`, `code-39`, `ean-13`, `QR`, `pdf417`. Use this to choose
+  the right barcode renderer. Also returned by the [product details
+  endpoint](/reference/2024-02-05/endpoint/products/list).
+</ResponseField>
+
+<ResponseField name="barcode_string" type="string">
+  The value to encode. Pass through your barcode library using
+  `barcode_format`.
+</ResponseField>
+
+<ResponseField name="pin" type="null">
+  Always `null` for this shape.
+</ResponseField>
+
+### Shape 3 — `type: "url"`
+
+The brand hosts redemption on their own site. Redirect the customer to `url`. There is no code to display.
+
+<ResponseField name="url" type="string">
+  Redirect the customer here to redeem.
+</ResponseField>
+
+<ResponseField name="code" type="string">
+  Duplicate of `url` — kept for backwards compatibility. Prefer `url`.
+</ResponseField>
+
+<ResponseField name="pin" type="null">
+  Always `null` for this shape.
+</ResponseField>
+
+<ResponseField name="barcode_format" type="null">
+  Always `null` for this shape.
+</ResponseField>
+
+<ResponseField name="barcode_string" type="null">
+  Always `null` for this shape.
+</ResponseField>
+
+## Examples
+
+<CodeGroup>
+```json Plain code
+{
+  "status": "SUCCESS",
+  "order_id": "O-XW2BQAM2",
+  "e_code": {
+    "type": "code",
+    "status": "SUCCESS",
+    "amount": "1.00",
+    "code": "WE3K-XTLHHZ-EKAL",
+    "pin": null,
+    "barcode_format": null,
+    "barcode_string": null,
+    "expiry_date": "2036-02-26",
+    "url": "https://spend.runa.io/-/88333b9f-ce8d-48f6-b851-eedd401cc3d2",
+    "error_code": null,
+    "error_string": null
+  },
+  "error_code": null,
+  "error_string": null,
+  "error_details": null
+}
+```
+
+```json Barcode
+{
+  "status": "SUCCESS",
+  "order_id": "O-QRXNZBJV",
+  "e_code": {
+    "type": "code",
+    "status": "SUCCESS",
+    "amount": "50.00",
+    "code": "6280399992147003",
+    "pin": null,
+    "barcode_format": "QR",
+    "barcode_string": "54390399548343003",
+    "expiry_date": "2025-02-28",
+    "url": "https://spend.runa.io/-/9b98244b-ab9b-4bff-b5f6-7777786b9f62",
+    "error_code": null,
+    "error_string": null
+  },
+  "error_code": null,
+  "error_string": null,
+  "error_details": null
+}
+```
+
+```json URL
+{
+  "status": "SUCCESS",
+  "order_id": "O-N5PX9YBW",
+  "e_code": {
+    "type": "url",
+    "status": "SUCCESS",
+    "amount": "10.00",
+    "code": "https://spend.runa.io/-/68802d8e-3e58-41dd-aea7-9e472debf656",
+    "pin": null,
+    "barcode_format": null,
+    "barcode_string": null,
+    "expiry_date": "2028-04-30",
+    "url": "https://spend.runa.io/-/68802d8e-3e58-41dd-aea7-9e472debf656",
+    "error_code": null,
+    "error_string": null
+  },
+  "error_code": null,
+  "error_string": null,
+  "error_details": null
+}
+```
+
+```json Error
+{
+  "status": "ERROR",
+  "order_id": "O-QRXNZBJV",
+  "error_code": "RE004",
+  "error_string": "The e-code has expired. You may need to place a new order.",
+  "error_details": "Asset has expired"
+}
+```
+</CodeGroup>
 
 ## Error codes
 
@@ -136,38 +288,3 @@ GET {payout.url}?format=json
 GET https://spend.runa.io/-/abc123…def?format=json
 ```
 </RequestExample>
-
-<ResponseExample>
-```json Success response
-{
-  "status": "SUCCESS",
-  "order_id": "O-QRXNZBJV",
-  "e_code": {
-    "amount": "50.00",
-    "barcode_format": "QR",
-    "barcode_string": "54390399548343003",
-    "code": "6280399992147003",
-    "error_code": null,
-    "error_string": null,
-    "expiry_date": "2025-02-28",
-    "pin": "25468113",
-    "status": "SUCCESS",
-    "type": "code",
-    "url": "https://spend.runa.io/-/9b98244b-ab9b-4bff-b5f6-7777786b9f62"
-  },
-  "error_code": null,
-  "error_details": null,
-  "error_string": null
-}
-```
-
-```json Error response
-{
-  "status": "ERROR",
-  "order_id": "O-QRXNZBJV",
-  "error_code": "RE004",
-  "error_details": "Asset has expired",
-  "error_string": "The e-code has expired. You may need to place a new order."
-}
-```
-</ResponseExample>

--- a/features/redemption-api.mdx
+++ b/features/redemption-api.mdx
@@ -141,6 +141,41 @@ To see each response shape in practice, place a sync order for one of the produc
 | `ABO-GB`     | GBP, face value `5`   | `type: "code"`, with `code` + `pin` + `QR` barcode       |
 | `LUSH-CA`    | CAD, face value `10`  | `type: "url"`                                            |
 
+<CodeGroup>
+```json Success
+{
+  "status": "SUCCESS",
+  "order_id": "O-QRXNZBJV",
+  "e_code": {
+    "type": "code",
+    "status": "SUCCESS",
+    "amount": "5.00",
+    "code": "7756580246805369",
+    "pin": "359000",
+    "barcode_format": "QR",
+    "barcode_string": "7756580246805369",
+    "expiry_date": "2028-04-30",
+    "url": "https://spend.runa.io/-/cc3ec71d-6086-4bb7-a61a-55b42e098233",
+    "error_code": null,
+    "error_string": null
+  },
+  "error_code": null,
+  "error_string": null,
+  "error_details": null
+}
+```
+
+```json Error
+{
+  "status": "ERROR",
+  "order_id": "O-QRXNZBJV",
+  "error_code": "RE004",
+  "error_string": "The e-code has expired. You may need to place a new order.",
+  "error_details": "Asset has expired"
+}
+```
+</CodeGroup>
+
 ## Error codes
 
 | Code    | Description                                                                                                    |

--- a/features/redemption-api.mdx
+++ b/features/redemption-api.mdx
@@ -132,86 +132,14 @@ GET {payout.url}?format=json
 
 ## Examples
 
-<CodeGroup>
-```json Code only
-{
-  "status": "SUCCESS",
-  "order_id": "O-XW2BQAM2",
-  "e_code": {
-    "type": "code",
-    "status": "SUCCESS",
-    "amount": "1.00",
-    "code": "WE3K-XTLHHZ-EKAL",
-    "pin": null,
-    "barcode_format": null,
-    "barcode_string": null,
-    "expiry_date": "2036-02-26",
-    "url": "https://spend.runa.io/-/88333b9f-ce8d-48f6-b851-eedd401cc3d2",
-    "error_code": null,
-    "error_string": null
-  },
-  "error_code": null,
-  "error_string": null,
-  "error_details": null
-}
-```
+To see each response shape in practice, place a sync order for one of the products below in the [Playground](/reference/2024-02-05/playground), then `GET` the resulting `payout.url` with `?format=json`.
 
-```json Code + PIN + barcode
-{
-  "status": "SUCCESS",
-  "order_id": "O-QRXNZBJV",
-  "e_code": {
-    "type": "code",
-    "status": "SUCCESS",
-    "amount": "50.00",
-    "code": "6280399992147003",
-    "pin": "25468113",
-    "barcode_format": "QR",
-    "barcode_string": "54390399548343003",
-    "expiry_date": "2025-02-28",
-    "url": "https://spend.runa.io/-/9b98244b-ab9b-4bff-b5f6-7777786b9f62",
-    "error_code": null,
-    "error_string": null
-  },
-  "error_code": null,
-  "error_string": null,
-  "error_details": null
-}
-```
-
-```json URL
-{
-  "status": "SUCCESS",
-  "order_id": "O-N5PX9YBW",
-  "e_code": {
-    "type": "url",
-    "status": "SUCCESS",
-    "amount": "10.00",
-    "code": "https://spend.runa.io/-/68802d8e-3e58-41dd-aea7-9e472debf656",
-    "pin": null,
-    "barcode_format": null,
-    "barcode_string": null,
-    "expiry_date": "2028-04-30",
-    "url": "https://spend.runa.io/-/68802d8e-3e58-41dd-aea7-9e472debf656",
-    "error_code": null,
-    "error_string": null
-  },
-  "error_code": null,
-  "error_string": null,
-  "error_details": null
-}
-```
-
-```json Error
-{
-  "status": "ERROR",
-  "order_id": "O-QRXNZBJV",
-  "error_code": "RE004",
-  "error_string": "The e-code has expired. You may need to place a new order.",
-  "error_details": "Asset has expired"
-}
-```
-</CodeGroup>
+| Product code | Order as              | Returned shape                                           |
+| ------------ | --------------------- | -------------------------------------------------------- |
+| `FIVEG-US`   | USD, face value `5`   | `type: "code"`, with `code` + `pin`                      |
+| `AUCHAN-FR`  | EUR, face value `10`  | `type: "code"`, with `code` + `pin` + `code-128` barcode |
+| `ABO-GB`     | GBP, face value `5`   | `type: "code"`, with `code` + `pin` + `QR` barcode       |
+| `LUSH-CA`    | CAD, face value `10`  | `type: "url"`                                            |
 
 ## Error codes
 

--- a/features/redemption-api.mdx
+++ b/features/redemption-api.mdx
@@ -76,7 +76,7 @@ The `e_code.type` field tells you how to render the gift card. There are three s
 | `type`   | When to use it                                 | Render as                          |
 | -------- | ---------------------------------------------- | ---------------------------------- |
 | `code`   | Plain alphanumeric code (with optional PIN)    | Display `code` (and `pin` if set)  |
-| `code`   | Barcode-backed code                            | Display `code` and render a barcode from `barcode_string` using `barcode_format` |
+| `code`   | Barcode-backed redemption                      | Render a barcode from `barcode_string` using `barcode_format` (no `code` is returned) |
 | `url`    | Redemption hosted by the brand                 | Redirect the customer to `url`     |
 
 ### Common `e_code` fields
@@ -136,11 +136,7 @@ The customer redeems by entering the `code` (and `pin`, if present) at the brand
 
 ### Shape 2 — `type: "code"`, barcode
 
-The customer redeems by scanning a barcode in-store. `barcode_format` and `barcode_string` are always set together — you need the format to decode the string. `pin` is always `null` for this shape.
-
-<ResponseField name="code" type="string">
-  The gift card code (also encoded in the barcode).
-</ResponseField>
+The customer redeems by scanning a barcode in-store. Render the barcode from `barcode_string` using `barcode_format` — those two fields are always set together, since you need the format to decode the string. `code` and `pin` are always `null` for this shape.
 
 <ResponseField name="barcode_format" type="string">
   One of `code-128`, `code-39`, `ean-13`, `QR`, `pdf417`. Use this to choose
@@ -151,6 +147,10 @@ The customer redeems by scanning a barcode in-store. `barcode_format` and `barco
 <ResponseField name="barcode_string" type="string">
   The value to encode. Pass through your barcode library using
   `barcode_format`.
+</ResponseField>
+
+<ResponseField name="code" type="null">
+  Always `null` for this shape.
 </ResponseField>
 
 <ResponseField name="pin" type="null">
@@ -215,7 +215,7 @@ The brand hosts redemption on their own site. Redirect the customer to `url`. Th
     "type": "code",
     "status": "SUCCESS",
     "amount": "50.00",
-    "code": "6280399992147003",
+    "code": null,
     "pin": null,
     "barcode_format": "QR",
     "barcode_string": "54390399548343003",

--- a/features/redemption-api.mdx
+++ b/features/redemption-api.mdx
@@ -141,41 +141,6 @@ To see each response shape in practice, place a sync order for one of the produc
 | `ABO-GB`     | GBP, face value `5`   | `type: "code"`, with `code` + `pin` + `QR` barcode       |
 | `LUSH-CA`    | CAD, face value `10`  | `type: "url"`                                            |
 
-<CodeGroup>
-```json Success
-{
-  "status": "SUCCESS",
-  "order_id": "O-QRXNZBJV",
-  "e_code": {
-    "type": "code",
-    "status": "SUCCESS",
-    "amount": "5.00",
-    "code": "7756580246805369",
-    "pin": "359000",
-    "barcode_format": "QR",
-    "barcode_string": "7756580246805369",
-    "expiry_date": "2028-04-30",
-    "url": "https://spend.runa.io/-/cc3ec71d-6086-4bb7-a61a-55b42e098233",
-    "error_code": null,
-    "error_string": null
-  },
-  "error_code": null,
-  "error_string": null,
-  "error_details": null
-}
-```
-
-```json Error
-{
-  "status": "ERROR",
-  "order_id": "O-QRXNZBJV",
-  "error_code": "RE004",
-  "error_string": "The e-code has expired. You may need to place a new order.",
-  "error_details": "Asset has expired"
-}
-```
-</CodeGroup>
-
 ## Error codes
 
 | Code    | Description                                                                                                    |
@@ -200,3 +165,38 @@ To see each response shape in practice, place a sync order for one of the produc
 GET https://spend.runa.io/-/abc123…def?format=json
 ```
 </RequestExample>
+
+<ResponseExample>
+```json Success
+{
+  "status": "SUCCESS",
+  "order_id": "O-QRXNZBJV",
+  "e_code": {
+    "type": "code",
+    "status": "SUCCESS",
+    "amount": "5.00",
+    "code": "1234567890123456",
+    "pin": "123456",
+    "barcode_format": "QR",
+    "barcode_string": "1234567890123456",
+    "expiry_date": "2028-04-30",
+    "url": "https://spend.runa.io/-/abc123…def",
+    "error_code": null,
+    "error_string": null
+  },
+  "error_code": null,
+  "error_string": null,
+  "error_details": null
+}
+```
+
+```json Error
+{
+  "status": "ERROR",
+  "order_id": "O-QRXNZBJV",
+  "error_code": "RE004",
+  "error_string": "The e-code has expired. You may need to place a new order.",
+  "error_details": "Asset has expired"
+}
+```
+</ResponseExample>

--- a/features/redemption-api.mdx
+++ b/features/redemption-api.mdx
@@ -71,13 +71,17 @@ The top-level fields below are present on every response. The contents of `e_cod
 
 ## Response shapes
 
-The `e_code.type` field tells you how to render the gift card. There are three shapes in practice:
+The `e_code.type` field tells you how to render the gift card:
 
-| `type`   | When to use it                                 | Render as                          |
-| -------- | ---------------------------------------------- | ---------------------------------- |
-| `code`   | Plain alphanumeric code (with optional PIN)    | Display `code` (and `pin` if set)  |
-| `code`   | Barcode-backed redemption                      | Render a barcode from `barcode_string` using `barcode_format` (no `code` is returned) |
-| `url`    | Redemption hosted by the brand                 | Redirect the customer to `url`     |
+| `type`   | What's returned                                                              | How to render                                                  |
+| -------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `code`   | Some non-empty subset of `code`, `pin`, and a barcode                        | Display whichever of `code`, `pin`, and the barcode are non-null |
+| `url`    | A redemption `url` hosted by the brand                                       | Redirect the customer to `url`                                 |
+
+<Note>
+  For `type: "code"`, the simplest integration is to render whatever fields
+  are non-null rather than branching on which combination you got back.
+</Note>
 
 ### Common `e_code` fields
 
@@ -113,51 +117,39 @@ These fields are present on every shape:
   Per-`e_code` error description, or `null`.
 </ResponseField>
 
-### Shape 1 — `type: "code"`, plain code
+### `type: "code"`
 
-The customer redeems by entering the `code` (and `pin`, if present) at the brand. Barcode fields are `null`.
+The response includes a non-empty subset of `code`, `pin`, and a barcode (`barcode_format` + `barcode_string`). Any of the following combinations can occur:
+
+- `code` only
+- `pin` only
+- `code` + `pin`
+- `code` + barcode
+- `pin` + barcode
+- `code` + `pin` + barcode
+
+Fields not part of the redemption are returned as `null`. To keep your integration simple, just render whatever is non-null.
 
 <ResponseField name="code" type="string">
-  The gift card code.
+  Alphanumeric gift card code, or `null`.
 </ResponseField>
 
 <ResponseField name="pin" type="string">
-  PIN, if the brand requires one. `null` otherwise. Only present on plain-code
-  redemptions — never set alongside a barcode.
+  PIN, or `null`.
 </ResponseField>
-
-<ResponseField name="barcode_format" type="null">
-  Always `null` for this shape.
-</ResponseField>
-
-<ResponseField name="barcode_string" type="null">
-  Always `null` for this shape.
-</ResponseField>
-
-### Shape 2 — `type: "code"`, barcode
-
-The customer redeems by scanning a barcode in-store. Render the barcode from `barcode_string` using `barcode_format` — those two fields are always set together, since you need the format to decode the string. `code` and `pin` are always `null` for this shape.
 
 <ResponseField name="barcode_format" type="string">
-  One of `code-128`, `code-39`, `ean-13`, `QR`, `pdf417`. Use this to choose
-  the right barcode renderer. Also returned by the [product details
+  One of `code-128`, `code-39`, `ean-13`, `QR`, `pdf417`, or `null`. Use this
+  to choose the right barcode renderer. Also returned by the [product details
   endpoint](/reference/2024-02-05/endpoint/products/list).
 </ResponseField>
 
 <ResponseField name="barcode_string" type="string">
-  The value to encode. Pass through your barcode library using
-  `barcode_format`.
+  The value to encode in the barcode, or `null`. Always set together with
+  `barcode_format` — you need the format to decode the string.
 </ResponseField>
 
-<ResponseField name="code" type="null">
-  Always `null` for this shape.
-</ResponseField>
-
-<ResponseField name="pin" type="null">
-  Always `null` for this shape.
-</ResponseField>
-
-### Shape 3 — `type: "url"`
+### `type: "url"`
 
 The brand hosts redemption on their own site. Redirect the customer to `url`. There is no code to display.
 
@@ -184,7 +176,7 @@ The brand hosts redemption on their own site. Redirect the customer to `url`. Th
 ## Examples
 
 <CodeGroup>
-```json Plain code
+```json Code only
 {
   "status": "SUCCESS",
   "order_id": "O-XW2BQAM2",
@@ -207,7 +199,7 @@ The brand hosts redemption on their own site. Redirect the customer to `url`. Th
 }
 ```
 
-```json Barcode
+```json Code + PIN + barcode
 {
   "status": "SUCCESS",
   "order_id": "O-QRXNZBJV",
@@ -215,8 +207,8 @@ The brand hosts redemption on their own site. Redirect the customer to `url`. Th
     "type": "code",
     "status": "SUCCESS",
     "amount": "50.00",
-    "code": null,
-    "pin": null,
+    "code": "6280399992147003",
+    "pin": "25468113",
     "barcode_format": "QR",
     "barcode_string": "54390399548343003",
     "expiry_date": "2025-02-28",

--- a/features/redemption-api.mdx
+++ b/features/redemption-api.mdx
@@ -64,14 +64,9 @@ The top-level fields below are present on every response. The contents of `e_cod
   Additional error details, or `null`.
 </ResponseField>
 
-<ResponseField name="e_code" type="object">
-  The gift card redemption details. See [`e_code` object](#e-code-object)
-  below.
-</ResponseField>
-
 ## `e_code` object
 
-The `type` field determines how to render the gift card:
+The gift card redemption details. The `type` field determines how to render the gift card:
 
 - **`type: "code"`** — display whichever of `code`, `pin`, `barcode_format`, and `barcode_string` are non-null. The brand decides which subset is populated; render whatever is available rather than branching on the combination.
 - **`type: "url"`** — redirect the customer to `url`. The `code` field duplicates `url` (kept for backwards compatibility); `pin` and the barcode fields are always `null`.

--- a/features/redemption-api.mdx
+++ b/features/redemption-api.mdx
@@ -65,35 +65,21 @@ The top-level fields below are present on every response. The contents of `e_cod
 </ResponseField>
 
 <ResponseField name="e_code" type="object">
-  The gift card redemption details. The populated fields depend on
-  `e_code.type` — see [Response shapes](#response-shapes) below.
+  The gift card redemption details. See [`e_code` object](#e-code-object)
+  below.
 </ResponseField>
 
-## Response shapes
+## `e_code` object
 
-The `e_code.type` field tells you how to render the gift card:
+The `type` field determines how to render the gift card:
 
-| `type`   | What's returned                                                              | How to render                                                  |
-| -------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| `code`   | Some non-empty subset of `code`, `pin`, and a barcode                        | Display whichever of `code`, `pin`, and the barcode are non-null |
-| `url`    | A redemption `url` hosted by the brand                                       | Redirect the customer to `url`                                 |
+- **`type: "code"`** — display whichever of `code`, `pin`, `barcode_format`, and `barcode_string` are non-null. The brand decides which subset is populated; render whatever is available rather than branching on the combination.
+- **`type: "url"`** — redirect the customer to `url`. The `code` field duplicates `url` (kept for backwards compatibility); `pin` and the barcode fields are always `null`.
 
-<Note>
-  For `type: "code"`, the simplest integration is to render whatever fields
-  are non-null rather than branching on which combination you got back.
-</Note>
-
-### Common `e_code` fields
-
-These fields are present on every shape:
+See [Examples](#examples) for representative payloads.
 
 <ResponseField name="type" type="string">
-  `code` or `url`. Determines which other fields are populated.
-</ResponseField>
-
-<ResponseField name="status" type="string">
-  Mirrors the top-level `status`. Always equal to it — provided for backwards
-  compatibility.
+  `code` or `url`.
 </ResponseField>
 
 <ResponseField name="amount" type="string">
@@ -109,29 +95,8 @@ These fields are present on every shape:
   A URL where the customer can access their gift card. Always present.
 </ResponseField>
 
-<ResponseField name="error_code" type="string">
-  Per-`e_code` error code, or `null`. See [Error codes](#error-codes).
-</ResponseField>
-
-<ResponseField name="error_string" type="string">
-  Per-`e_code` error description, or `null`.
-</ResponseField>
-
-### `type: "code"`
-
-The response includes a non-empty subset of `code`, `pin`, and a barcode (`barcode_format` + `barcode_string`). Any of the following combinations can occur:
-
-- `code` only
-- `pin` only
-- `code` + `pin`
-- `code` + barcode
-- `pin` + barcode
-- `code` + `pin` + barcode
-
-Fields not part of the redemption are returned as `null`. To keep your integration simple, just render whatever is non-null.
-
 <ResponseField name="code" type="string">
-  Alphanumeric gift card code, or `null`.
+  Alphanumeric gift card code, or `null`. For `type: "url"`, duplicates `url`.
 </ResponseField>
 
 <ResponseField name="pin" type="string">
@@ -149,28 +114,16 @@ Fields not part of the redemption are returned as `null`. To keep your integrati
   `barcode_format` — you need the format to decode the string.
 </ResponseField>
 
-### `type: "url"`
-
-The brand hosts redemption on their own site. Redirect the customer to `url`. There is no code to display.
-
-<ResponseField name="url" type="string">
-  Redirect the customer here to redeem.
+<ResponseField name="status" type="string">
+  Mirrors the top-level `status`. Provided for backwards compatibility.
 </ResponseField>
 
-<ResponseField name="code" type="string">
-  Duplicate of `url` — kept for backwards compatibility. Prefer `url`.
+<ResponseField name="error_code" type="string">
+  Per-`e_code` error code, or `null`. See [Error codes](#error-codes).
 </ResponseField>
 
-<ResponseField name="pin" type="null">
-  Always `null` for this shape.
-</ResponseField>
-
-<ResponseField name="barcode_format" type="null">
-  Always `null` for this shape.
-</ResponseField>
-
-<ResponseField name="barcode_string" type="null">
-  Always `null` for this shape.
+<ResponseField name="error_string" type="string">
+  Per-`e_code` error description, or `null`.
 </ResponseField>
 
 ## Examples

--- a/features/redemption-api.mdx
+++ b/features/redemption-api.mdx
@@ -100,7 +100,7 @@ See [Examples](#examples) for representative payloads.
 
 <ResponseField name="barcode_format" type="string">
   One of `code-128`, `code-39`, `ean-13`, `QR`, `pdf417`, or `null`. Use this
-  to choose the right barcode renderer. Also returned by the [product details
+  to choose the right barcode renderer. Also returned by the [products list
   endpoint](/reference/2024-02-05/endpoint/products/list).
 </ResponseField>
 

--- a/features/redemption-api.mdx
+++ b/features/redemption-api.mdx
@@ -41,7 +41,7 @@ GET {payout.url}?format=json
 
 ## Response
 
-The top-level fields below are present on every response. The contents of `e_code` depend on the gift card `type` — see [`e_code` object](#e-code-object).
+The top-level fields below are present on every response. The contents of `e_code` depend on the gift card `type` — see [`e_code` object](#e_code-object).
 
 <ResponseField name="status" type="string">
   `SUCCESS` or `ERROR`. On `ERROR`, see the top-level `error_code` and

--- a/features/redemption-api.mdx
+++ b/features/redemption-api.mdx
@@ -142,7 +142,9 @@ To see each response shape in practice, place a sync order for one of the produc
 
 | Product code | Order as              | Returned shape                                           |
 | ------------ | --------------------- | -------------------------------------------------------- |
+| `BAW-GB`     | GBP, face value `5`   | `type: "code"`, with `code` only                         |
 | `FIVEG-US`   | USD, face value `5`   | `type: "code"`, with `code` + `pin`                      |
+| `CDISC-FR`   | EUR, face value `20`  | `type: "code"`, with `code` + `code-128` barcode         |
 | `AUCHAN-FR`  | EUR, face value `10`  | `type: "code"`, with `code` + `pin` + `code-128` barcode |
 | `ABO-GB`     | GBP, face value `5`   | `type: "code"`, with `code` + `pin` + `QR` barcode       |
 | `LUSH-CA`    | CAD, face value `10`  | `type: "url"`                                            |

--- a/features/redemption-api.mdx
+++ b/features/redemption-api.mdx
@@ -41,7 +41,7 @@ GET {payout.url}?format=json
 
 ## Response
 
-The wrapper is the same for every successful response:
+The top-level fields below are present on every response. The contents of `e_code` depend on the gift card `type` — see [Response shapes](#response-shapes).
 
 <ResponseField name="status" type="string">
   `SUCCESS` or `ERROR`. On `ERROR`, see the top-level `error_code` and

--- a/features/redemption-api.mdx
+++ b/features/redemption-api.mdx
@@ -100,8 +100,8 @@ See [Examples](#examples) for representative payloads.
 
 <ResponseField name="barcode_format" type="string">
   One of `code-128`, `code-39`, `ean-13`, `QR`, `pdf417`, or `null`. Use this
-  to choose the right barcode renderer. Also returned by the [products list
-  endpoint](/reference/2024-02-05/endpoint/products/list).
+  to choose the right barcode renderer. Also returned by the [get product
+  endpoint](/reference/2024-02-05/endpoint/products/get).
 </ResponseField>
 
 <ResponseField name="barcode_string" type="string">

--- a/features/redemption-api.mdx
+++ b/features/redemption-api.mdx
@@ -41,8 +41,6 @@ GET {payout.url}?format=json
 
 ## Response
 
-The top-level fields below are present on every response. The contents of `e_code` depend on the gift card `type` — see [`e_code` object](#e_code-object).
-
 <ResponseField name="status" type="string">
   `SUCCESS` or `ERROR`. On `ERROR`, see the top-level `error_code` and
   `error_string`. On `SUCCESS`, redemption details are in `e_code`.
@@ -64,62 +62,72 @@ The top-level fields below are present on every response. The contents of `e_cod
   Additional error details, or `null`.
 </ResponseField>
 
-## `e_code` object
+<ResponseField name="e_code" type="object">
+  The gift card redemption details. The `type` field determines how to render
+  the gift card:
 
-The gift card redemption details. The `type` field determines how to render the gift card:
+  - **`type: "code"`** — display whichever of `code`, `pin`, `barcode_format`,
+    and `barcode_string` are non-null. The brand decides which subset is
+    populated; render whatever is available rather than branching on the
+    combination.
+  - **`type: "url"`** — redirect the customer to `url`. The `code` field
+    duplicates `url` (kept for backwards compatibility); `pin` and the barcode
+    fields are always `null`.
 
-- **`type: "code"`** — display whichever of `code`, `pin`, `barcode_format`, and `barcode_string` are non-null. The brand decides which subset is populated; render whatever is available rather than branching on the combination.
-- **`type: "url"`** — redirect the customer to `url`. The `code` field duplicates `url` (kept for backwards compatibility); `pin` and the barcode fields are always `null`.
+  See [Examples](#examples) for representative payloads.
 
-See [Examples](#examples) for representative payloads.
+  <Expandable title="child attributes">
+    <ResponseField name="type" type="string">
+      `code` or `url`.
+    </ResponseField>
 
-<ResponseField name="type" type="string">
-  `code` or `url`.
-</ResponseField>
+    <ResponseField name="amount" type="string">
+      Amount in major units, as a decimal string (e.g. `"50.00"`).
+    </ResponseField>
 
-<ResponseField name="amount" type="string">
-  Amount in major units, as a decimal string (e.g. `"50.00"`).
-</ResponseField>
+    <ResponseField name="expiry_date" type="string">
+      Expiry date of the gift card. The sentinel value `3000-01-01` indicates
+      the gift card does not expire. This reflects the product's own expiry
+      policy and is separate from the payout link expiry returned by the order
+      endpoints.
+    </ResponseField>
 
-<ResponseField name="expiry_date" type="string">
-  Expiry date of the gift card. The sentinel value `3000-01-01` indicates the
-  gift card does not expire. This reflects the product's own expiry policy and
-  is separate from the payout link expiry returned by the order endpoints.
-</ResponseField>
+    <ResponseField name="url" type="string">
+      A URL where the customer can access their gift card. Always present.
+    </ResponseField>
 
-<ResponseField name="url" type="string">
-  A URL where the customer can access their gift card. Always present.
-</ResponseField>
+    <ResponseField name="code" type="string">
+      Alphanumeric gift card code, or `null`. For `type: "url"`, duplicates
+      `url`.
+    </ResponseField>
 
-<ResponseField name="code" type="string">
-  Alphanumeric gift card code, or `null`. For `type: "url"`, duplicates `url`.
-</ResponseField>
+    <ResponseField name="pin" type="string">
+      PIN, or `null`.
+    </ResponseField>
 
-<ResponseField name="pin" type="string">
-  PIN, or `null`.
-</ResponseField>
+    <ResponseField name="barcode_format" type="string">
+      One of `code-128`, `code-39`, `ean-13`, `QR`, `pdf417`, or `null`. Use
+      this to choose the right barcode renderer. Also returned by the [get
+      product endpoint](/reference/2024-02-05/endpoint/products/get).
+    </ResponseField>
 
-<ResponseField name="barcode_format" type="string">
-  One of `code-128`, `code-39`, `ean-13`, `QR`, `pdf417`, or `null`. Use this
-  to choose the right barcode renderer. Also returned by the [get product
-  endpoint](/reference/2024-02-05/endpoint/products/get).
-</ResponseField>
+    <ResponseField name="barcode_string" type="string">
+      The value to encode in the barcode, or `null`. Always set together with
+      `barcode_format` — you need the format to decode the string.
+    </ResponseField>
 
-<ResponseField name="barcode_string" type="string">
-  The value to encode in the barcode, or `null`. Always set together with
-  `barcode_format` — you need the format to decode the string.
-</ResponseField>
+    <ResponseField name="status" type="string">
+      Mirrors the top-level `status`. Provided for backwards compatibility.
+    </ResponseField>
 
-<ResponseField name="status" type="string">
-  Mirrors the top-level `status`. Provided for backwards compatibility.
-</ResponseField>
+    <ResponseField name="error_code" type="string">
+      Per-`e_code` error code, or `null`. See [Error codes](#error-codes).
+    </ResponseField>
 
-<ResponseField name="error_code" type="string">
-  Per-`e_code` error code, or `null`. See [Error codes](#error-codes).
-</ResponseField>
-
-<ResponseField name="error_string" type="string">
-  Per-`e_code` error description, or `null`.
+    <ResponseField name="error_string" type="string">
+      Per-`e_code` error description, or `null`.
+    </ResponseField>
+  </Expandable>
 </ResponseField>
 
 ## Examples

--- a/features/redemption-api.mdx
+++ b/features/redemption-api.mdx
@@ -147,6 +147,11 @@ To see each response shape in practice, place a sync order for one of the produc
 | `ABO-GB`     | GBP, face value `5`   | `type: "code"`, with `code` + `pin` + `QR` barcode       |
 | `LUSH-CA`    | CAD, face value `10`  | `type: "url"`                                            |
 
+<Note>
+  The brand decides which subset is populated; render whatever is available
+  rather than branching on the combination.
+</Note>
+
 ## Error codes
 
 | Code    | Description                                                                                                    |

--- a/features/redemption-api.mdx
+++ b/features/redemption-api.mdx
@@ -41,6 +41,12 @@ GET {payout.url}?format=json
 
 ## Response
 
+<Note>
+  Both success and error responses return HTTP `200`. Check the JSON `status`
+  field (and `error_code` when it's `ERROR`) to distinguish them — don't rely
+  on the HTTP status code.
+</Note>
+
 <ResponseField name="status" type="string">
   `SUCCESS` or `ERROR`. On `ERROR`, see the top-level `error_code` and
   `error_string`. On `SUCCESS`, redemption details are in `e_code`.


### PR DESCRIPTION
  ## Summary                                                                                                                                                                          
  - Restructure the Redemption API page around the three real `e_code` shapes (plain code, barcode, url) instead of a single flat field list, so readers can tell which fields are    
  populated when.                                                                                                                                                                     
  - Fix an incorrect claim that `pin` contains the URL for `url`-type products — `pin` is plain-code-only, and the URL lives in `code` (duplicate of `url`) and `url`.                
  - Document a few quirks that previously weren't called out: `code === url` for `url`-type, `e_code.status` mirrors top-level `status`, `barcode_format` and `barcode_string` are    
  always paired, `3000-01-01` is the no-expiry sentinel.                                                                                                                              
  - Pull the rate-limiting note out of the `format` param description into its own callout, and state that the payout URL itself is the credential.                                   
  - Replace the single example with a `<CodeGroup>` covering all three success shapes plus the error case.                                                                            
                                                                                                                                                                                      
  ## Test plan                                                                                                                                                                        
  - [ ] Render the page locally with `mintlify dev` and confirm rendering                                                                                                             
  - [ ] Spot-check that the three example payloads match real API output                                                                                                              
  - [ ] Confirm `pin` documentation now matches reality (plain-code only)   