### PR TITLE
[NCE-917] Update docs for prepaid cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.pnpm-store

--- a/docs.json
+++ b/docs.json
@@ -79,6 +79,7 @@
                 "icon": "credit-card",
                 "pages": [
                   "features/prepaid-visa/introduction",
+                  "features/prepaid-visa/spend-controls",
                   "features/prepaid-visa/support"
                 ]
               }

--- a/features/prepaid-visa/introduction.mdx
+++ b/features/prepaid-visa/introduction.mdx
@@ -73,54 +73,9 @@ In the example above we used the `EMAIL` distribution method to send the card to
 
 - You can also use the `PAYOUT_LINK` distribution method to receive a link in the API response and handle distribution yourself.
 
-## Attaching an MCC-rules template
+## Controlling where a card can be spent
 
-You can control where a prepaid Visa card can be spent by attaching a **Runa-authored MCC-rules template** to the card. A template bundles a set of restrictions — such as Merchant Category Code (MCC) allow/deny lists — that are applied to the issued card.
-
-To attach a template, add a `product_usage_config` object to the `SINGLE` product and set its `spend_rules_template_id` to the identifier of the template you want to apply.
-
-```http title="Example Prepaid Visa Card order with an MCC-rules template" icon="globe" expandable
-POST https://api.runa.io/v2/order
-Content-Type: application/json
-X-Api-Key: <your API key>
-
-{
-    "payment_method": {
-        "type": "ACCOUNT_BALANCE",
-        "currency": "USD"
-    },
-    "items": [
-        {
-            "face_value": 10,
-            "distribution_method": {
-                "type": "EMAIL",
-                "email_address": "<your recipient's email address>"
-            },
-            "products": {
-                "type": "SINGLE",
-                "value": "VISASL-3M-USD",
-                "product_usage_config": {
-                    "spend_rules_template_id": "PSR-01HW3CXZJD5K9PMNRTV0Y4QF7B"
-                }
-            }
-        }
-    ]
-}
-```
-
-When you set `product_usage_config` on an order, it is returned in the [order details](/reference/2024-02-05/endpoint/orders/get) so you can confirm which template was applied.
-
-<Info>
-  Spend rule templates are authored by Runa. A single template is applied per
-  card, with multiple restrictions bundled inside it. Template identifiers are
-  immutable — any change ships as a new template with a new ID. To request a
-  template, reach out to your Account Manager or email support@runa.io.
-</Info>
-
-<Note>
-  `product_usage_config` only applies to prepaid Visa cards. If you set it on
-  any other product it is ignored.
-</Note>
+You can restrict where a prepaid Visa card can be spent by attaching a Runa-authored spend rule template to the card. See [Card spend controls](/features/prepaid-visa/spend-controls) for details and a worked example.
 
 ## Reloading a Prepaid Visa Card
 

--- a/features/prepaid-visa/introduction.mdx
+++ b/features/prepaid-visa/introduction.mdx
@@ -11,20 +11,21 @@ Runa Prepaid Cards are instantly delivered, digital Visa prepaid cards that reci
 - **Two prepaid options**: Enable both the Runa Reward Card and the Runa Reload Card for your business needs
 
 <Info>
-  To get access to Prepaid Visa Cards, please reach out to your Account Manager or
-  email support@runa.io.
+  To get access to Prepaid Visa Cards, please reach out to your Account Manager
+  or email support@runa.io.
 </Info>
 
 ## Card types
 
-| | Runa Reload Card | Runa Reward Card |
-|---|---|---|
-| **Type** | Reloadable | Single-load |
-| **Expiry** | 47 months from first activation | 3, 6, or 12 months from first activation |
-| **Product code** | `VISARL-USD` | `VISASL-3M-USD`, `VISASL-6M-USD`, `VISASL-12M-USD` |
+|                  | Runa Reload Card                | Runa Reward Card                                   |
+| ---------------- | ------------------------------- | -------------------------------------------------- |
+| **Type**         | Reloadable                      | Single-load                                        |
+| **Expiry**       | 47 months from first activation | 3, 6, or 12 months from first activation           |
+| **Product code** | `VISARL-USD`                    | `VISASL-3M-USD`, `VISASL-6M-USD`, `VISASL-12M-USD` |
 
 <Warning>
-  For Reload Cards, recipients must use the same email address the card was originally sent to. Future top-ups will fail if a different email is used.
+  For Reload Cards, recipients must use the same email address the card was
+  originally sent to. Future top-ups will fail if a different email is used.
 </Warning>
 
 ## Getting started
@@ -71,6 +72,55 @@ X-Api-Key: <your API key>
 In the example above we used the `EMAIL` distribution method to send the card to the recipient's email address.
 
 - You can also use the `PAYOUT_LINK` distribution method to receive a link in the API response and handle distribution yourself.
+
+## Attaching an MCC-rules template
+
+You can control where a prepaid Visa card can be spent by attaching a **Runa-authored MCC-rules template** to the card. A template bundles a set of restrictions — such as Merchant Category Code (MCC) allow/deny lists — that are applied to the issued card.
+
+To attach a template, add a `product_usage_config` object to the `SINGLE` product and set its `spend_rules_template_id` to the identifier of the template you want to apply.
+
+```http title="Example Prepaid Visa Card order with an MCC-rules template" icon="globe" expandable
+POST https://api.runa.io/v2/order
+Content-Type: application/json
+X-Api-Key: <your API key>
+
+{
+    "payment_method": {
+        "type": "ACCOUNT_BALANCE",
+        "currency": "USD"
+    },
+    "items": [
+        {
+            "face_value": 10,
+            "distribution_method": {
+                "type": "EMAIL",
+                "email_address": "<your recipient's email address>"
+            },
+            "products": {
+                "type": "SINGLE",
+                "value": "VISASL-3M-USD",
+                "product_usage_config": {
+                    "spend_rules_template_id": "PSR-01HW3CXZJD5K9PMNRTV0Y4QF7B"
+                }
+            }
+        }
+    ]
+}
+```
+
+When you set `product_usage_config` on an order, it is returned in the [order details](/reference/2024-02-05/endpoint/orders/get) so you can confirm which template was applied.
+
+<Info>
+  Spend rule templates are authored by Runa. A single template is applied per
+  card, with multiple restrictions bundled inside it. Template identifiers are
+  immutable — any change ships as a new template with a new ID. To request a
+  template, reach out to your Account Manager or email support@runa.io.
+</Info>
+
+<Note>
+  `product_usage_config` only applies to prepaid Visa cards. If you set it on
+  any other product it is ignored.
+</Note>
 
 ## Reloading a Prepaid Visa Card
 

--- a/features/prepaid-visa/spend-controls.mdx
+++ b/features/prepaid-visa/spend-controls.mdx
@@ -8,7 +8,7 @@ You can control where a prepaid Visa card can be spent by attaching a **Runa-aut
 
 ## Attaching a template
 
-To attach a template, add a `product_usage_config` object to the `SINGLE` product and set its `spend_rules_template_id` to the identifier of the template you want to apply.
+To attach a template, add a `usage_config` object to the `SINGLE` product and set its `spend_rules_template_id` to the identifier of the template you want to apply.
 
 ```http title="Example Prepaid Visa Card order with a spend rule template" icon="globe" expandable
 POST https://api.runa.io/v2/order
@@ -30,7 +30,7 @@ X-Api-Key: <your API key>
             "products": {
                 "type": "SINGLE",
                 "value": "VISASL-3M-USD",
-                "product_usage_config": {
+                "usage_config": {
                     "spend_rules_template_id": "PSR-01HW3CXZJD5K9PMNRTV0Y4QF7B"
                 }
             }
@@ -39,7 +39,7 @@ X-Api-Key: <your API key>
 }
 ```
 
-When you set `product_usage_config` on an order, it is returned in the [order details](/reference/2024-02-05/endpoint/orders/get) so you can confirm which template was applied.
+When you set `usage_config` on an order, it is returned in the [order details](/reference/2024-02-05/endpoint/orders/get) so you can confirm which template was applied.
 
 <Info>
   Spend rule templates are authored by Runa. A single template is applied per
@@ -49,6 +49,6 @@ When you set `product_usage_config` on an order, it is returned in the [order de
 </Info>
 
 <Note>
-  `product_usage_config` only applies to prepaid Visa cards. If you set it on
-  any other product it is ignored.
+  `usage_config` only applies to prepaid Visa cards. If you set it on any other
+  product it is ignored.
 </Note>

--- a/features/prepaid-visa/spend-controls.mdx
+++ b/features/prepaid-visa/spend-controls.mdx
@@ -31,7 +31,7 @@ X-Api-Key: <your API key>
                 "type": "SINGLE",
                 "value": "VISASL-3M-USD",
                 "usage_config": {
-                    "spend_rules_template_id": "PSR-01HW3CXZJD5K9PMNRTV0Y4QF7B"
+                    "spend_rules_template_id": "<runa authored template id>"
                 }
             }
         }

--- a/features/prepaid-visa/spend-controls.mdx
+++ b/features/prepaid-visa/spend-controls.mdx
@@ -42,10 +42,12 @@ X-Api-Key: <your API key>
 When you set `usage_config` on an order, it is returned in the [order details](/reference/2024-02-05/endpoint/orders/get) so you can confirm which template was applied.
 
 <Info>
-  Spend rule templates are authored by Runa. A single template is applied per
-  card, with multiple restrictions bundled inside it. Template identifiers are
-  immutable — any change ships as a new template with a new ID. To request a
-  template, reach out to your Account Manager or email support@runa.io.
+  A spend rule template defines the spending pattern enforced on a card, based
+  on MCC rules — each rule either allows or blocks transactions for a given
+  merchant category. Multiple rules can be bundled into a single template, and
+  one template is applied per card. Templates are authored by Runa. If you have
+  a business case that needs one, reach out to your Account Manager or email
+  support@runa.io — we'll create the template for you.
 </Info>
 
 <Note>

--- a/features/prepaid-visa/spend-controls.mdx
+++ b/features/prepaid-visa/spend-controls.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Card spend controls"
-description: "Restrict where a prepaid Visa card can be spent using Runa-authored spend rule templates (Merchant Category Code (MCC) allow/deny lists)."
+description: "Limit which merchants a Prepaid Visa Card can be used for"
 icon: "shield-check"
 ---
 

--- a/features/prepaid-visa/spend-controls.mdx
+++ b/features/prepaid-visa/spend-controls.mdx
@@ -1,0 +1,54 @@
+---
+title: "Card spend controls"
+description: "Restrict where a prepaid Visa card can be spent using Runa-authored spend rule templates (Merchant Category Code (MCC) allow/deny lists)."
+icon: "shield-check"
+---
+
+You can control where a prepaid Visa card can be spent by attaching a **Runa-authored spend rule template** to the card. A template bundles a set of restrictions — such as Merchant Category Code (MCC) allow/deny lists — that are applied to the issued card.
+
+## Attaching a template
+
+To attach a template, add a `product_usage_config` object to the `SINGLE` product and set its `spend_rules_template_id` to the identifier of the template you want to apply.
+
+```http title="Example Prepaid Visa Card order with a spend rule template" icon="globe" expandable
+POST https://api.runa.io/v2/order
+Content-Type: application/json
+X-Api-Key: <your API key>
+
+{
+    "payment_method": {
+        "type": "ACCOUNT_BALANCE",
+        "currency": "USD"
+    },
+    "items": [
+        {
+            "face_value": 10,
+            "distribution_method": {
+                "type": "EMAIL",
+                "email_address": "<your recipient's email address>"
+            },
+            "products": {
+                "type": "SINGLE",
+                "value": "VISASL-3M-USD",
+                "product_usage_config": {
+                    "spend_rules_template_id": "PSR-01HW3CXZJD5K9PMNRTV0Y4QF7B"
+                }
+            }
+        }
+    ]
+}
+```
+
+When you set `product_usage_config` on an order, it is returned in the [order details](/reference/2024-02-05/endpoint/orders/get) so you can confirm which template was applied.
+
+<Info>
+  Spend rule templates are authored by Runa. A single template is applied per
+  card, with multiple restrictions bundled inside it. Template identifiers are
+  immutable — any change ships as a new template with a new ID. To request a
+  template, reach out to your Account Manager or email support@runa.io.
+</Info>
+
+<Note>
+  `product_usage_config` only applies to prepaid Visa cards. If you set it on
+  any other product it is ignored.
+</Note>

--- a/reference/2024-02-05/openapi.json
+++ b/reference/2024-02-05/openapi.json
@@ -1627,7 +1627,7 @@
             "description": "Identifier of a Runa-authored MCC-rules template applied to the issued card.\n\nOnly applicable to prepaid Visa cards. A single template is applied per card, with multiple rules that either allows or blocks transactions for a given merchant category bundled inside that one template.",
             "type": "string",
             "pattern": "^PSR-[0-9A-HJKMNP-TV-Z]{26}$",
-            "example": "PSR-01HW3CXZJD5K9PMNRTV0Y4QF7B"
+            "example": "PSR-XXXXXXXXXXXXXXXXXXXXXXXXXX"
           }
         }
       },

--- a/reference/2024-02-05/openapi.json
+++ b/reference/2024-02-05/openapi.json
@@ -1607,7 +1607,7 @@
             "type": "string"
           },
           "product_usage_config": {
-            "description": "Optional. **Only applicable to prepaid Visa cards.** Attaches an MCC-rules template to the issued card. Ignored for all other products. See [Using Prepaid Visa Cards](/features/prepaid-visa/introduction#attaching-an-mcc-rules-template) for a worked example. When it was set on a prepaid Visa card order, it is returned in the order details.",
+            "description": "Optional. **Only applicable to prepaid Visa cards.** Attaches an MCC-rules template to the issued card. Ignored for all other products. See [Using Prepaid Visa Cards](/features/prepaid-visa/introduction#attaching-an-mcc-rules-template) for a worked example. When set on a prepaid Visa card order, it is returned in the order details.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/ProductUsageConfig"

--- a/reference/2024-02-05/openapi.json
+++ b/reference/2024-02-05/openapi.json
@@ -1624,7 +1624,7 @@
         "properties": {
           "spend_rules_template_id": {
             "title": "MCC rules template ID",
-            "description": "Identifier of a Runa-authored MCC-rules template applied to the issued card.\n\nOnly applicable to prepaid Visa cards. A single template is applied per card, with multiple restrictions bundled inside that one template. Template identifiers are immutable — changes ship as a new template with a new ID.",
+            "description": "Identifier of a Runa-authored MCC-rules template applied to the issued card.\n\nOnly applicable to prepaid Visa cards. A single template is applied per card, with multiple rules that either allows or blocks transactions for a given merchant category bundled inside that one template.",
             "type": "string",
             "pattern": "^PSR-[0-9A-HJKMNP-TV-Z]{26}$",
             "example": "PSR-01HW3CXZJD5K9PMNRTV0Y4QF7B"

--- a/reference/2024-02-05/openapi.json
+++ b/reference/2024-02-05/openapi.json
@@ -1607,7 +1607,7 @@
             "type": "string"
           },
           "product_usage_config": {
-            "description": "Optional. **Only applicable to prepaid Visa cards.** Attaches an MCC-rules template to the issued card. Ignored for all other products. See [Using Prepaid Visa Cards](/features/prepaid-visa/introduction#attaching-an-mcc-rules-template) for a worked example. When set on a prepaid Visa card order, it is returned in the order details.",
+            "description": "Optional. **Only applicable to prepaid Visa cards.** Attaches an MCC-rules template to the issued card. Ignored for all other products. See [Card spend controls](/features/prepaid-visa/spend-controls) for a worked example. When set on a prepaid Visa card order, it is returned in the order details.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/ProductUsageConfig"

--- a/reference/2024-02-05/openapi.json
+++ b/reference/2024-02-05/openapi.json
@@ -1610,15 +1610,15 @@
             "description": "Optional. **Only applicable to prepaid Visa cards.** Attaches an MCC-rules template to the issued card. Ignored for all other products. See [Card spend controls](/features/prepaid-visa/spend-controls) for a worked example. When set on a prepaid Visa card order, it is returned in the order details.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/ProductUsageConfig"
+                "$ref": "#/components/schemas/UsageConfig"
               }
             ]
           }
         },
         "description": "Single product. The end user will be able to redeem the payout link for this specific product."
       },
-      "ProductUsageConfig": {
-        "title": "ProductUsageConfig",
+      "UsageConfig": {
+        "title": "UsageConfig",
         "type": "object",
         "description": "Additional configuration applied to the issued product. Only applicable to prepaid Visa cards.",
         "properties": {

--- a/reference/2024-02-05/openapi.json
+++ b/reference/2024-02-05/openapi.json
@@ -864,7 +864,7 @@
                 "$ref": "#/components/schemas/MultipleProduct"
               },
               {
-                "$ref": "#/components/schemas/SingleProduct"
+                "$ref": "#/components/schemas/SingleProductWithUsageConfig"
               },
               {
                 "$ref": "#/components/schemas/PayoutSelectionTemplateDetailed"
@@ -1268,7 +1268,7 @@
             "description": "Choose `SINGLE` if you want the end user to redeem the face value on a single specific product. Choose `MULTIPLE` if the end user can choose to spend the face value across multiple products.",
             "oneOf": [
               {
-                "$ref": "#/components/schemas/SingleProduct"
+                "$ref": "#/components/schemas/SingleProductWithUsageConfig"
               },
               {
                 "$ref": "#/components/schemas/MultipleProduct"
@@ -1586,6 +1586,50 @@
         "type": "string",
         "enum": ["SINGLE"],
         "description": "Single product. When only one product code is provided."
+      },
+      "SingleProductWithUsageConfig": {
+        "title": "Single",
+        "required": ["type", "value"],
+        "type": "object",
+        "example": {
+          "type": "SINGLE",
+          "value": "AMZ-US"
+        },
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/SingleProductType"
+          },
+          "value": {
+            "title": "Value",
+            "description": "The code for the product the end user will get when redeeming their payout link.",
+            "minLength": 1,
+            "example": "AMZ-US",
+            "type": "string"
+          },
+          "product_usage_config": {
+            "description": "Optional. **Only applicable to prepaid Visa cards.** Attaches an MCC-rules template to the issued card. Ignored for all other products. See [Using Prepaid Visa Cards](/features/prepaid-visa/introduction#attaching-an-mcc-rules-template) for a worked example. When it was set on a prepaid Visa card order, it is returned in the order details.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProductUsageConfig"
+              }
+            ]
+          }
+        },
+        "description": "Single product. The end user will be able to redeem the payout link for this specific product."
+      },
+      "ProductUsageConfig": {
+        "title": "ProductUsageConfig",
+        "type": "object",
+        "description": "Additional configuration applied to the issued product. Only applicable to prepaid Visa cards.",
+        "properties": {
+          "spend_rules_template_id": {
+            "title": "MCC rules template ID",
+            "description": "Identifier of a Runa-authored MCC-rules template applied to the issued card.\n\nOnly applicable to prepaid Visa cards. A single template is applied per card, with multiple restrictions bundled inside that one template. Template identifiers are immutable — changes ship as a new template with a new ID.",
+            "type": "string",
+            "pattern": "^PSR-[0-9A-HJKMNP-TV-Z]{26}$",
+            "example": "PSR-01HW3CXZJD5K9PMNRTV0Y4QF7B"
+          }
+        }
       },
       "MultipleProduct": {
         "title": "Multiple",

--- a/reference/2024-02-05/openapi.json
+++ b/reference/2024-02-05/openapi.json
@@ -1606,7 +1606,7 @@
             "example": "AMZ-US",
             "type": "string"
           },
-          "product_usage_config": {
+          "usage_config": {
             "description": "Optional. **Only applicable to prepaid Visa cards.** Attaches an MCC-rules template to the issued card. Ignored for all other products. See [Card spend controls](/features/prepaid-visa/spend-controls) for a worked example. When set on a prepaid Visa card order, it is returned in the order details.",
             "allOf": [
               {


### PR DESCRIPTION
Adds public-docs coverage for the new optional `usage_config.spend_rules_template_id` field, which attaches a Runa-authored MCC-rules template to an issued prepaid Visa card.


Changes
OpenAPI: added `UsageConfig` and a dedicated `SingleProductWithUsageConfig` schema, wired into the create order request and get order details response only. Shared `SingleProduct` left untouched. Descriptions note it's prepaid-Visa-only and echoed back when set.\
Guide: Added a new page called 'Card spend controls' where it's explained everything MCC related

https://runa-nce-917.mintlify.app/

Usage config mentioned in the request body field for Create order\
<img width="1215" height="801" alt="image" src="https://github.com/user-attachments/assets/ee966554-90b6-4908-8c47-1b816f57bcb4" />

mentioned in Using Prepaid Visa Cards\
<img width="1237" height="810" alt="image" src="https://github.com/user-attachments/assets/006cc62f-91d5-4f51-9205-65621885e49d" />

New page Card spend controls\
<img width="1230" height="772" alt="image" src="https://github.com/user-attachments/assets/5c16e9c5-f231-44bd-a812-34503f5baa79" />\
<img width="1232" height="819" alt="image" src="https://github.com/user-attachments/assets/98487045-5aa5-4fa4-bc94-2731b07e113d" />\
<img width="1264" height="786" alt="image" src="https://github.com/user-attachments/assets/b9fd8873-21bf-42c1-9c15-12fd9860ecfe" />






