### PR TITLE
Allow up to 4 decimal places for discount_multiplier

### DIFF
--- a/reference/2024-02-05/openapi.json
+++ b/reference/2024-02-05/openapi.json
@@ -2086,7 +2086,7 @@
       },
       "ProductDiscountMultiplier": {
         "type": "string",
-        "pattern": "^[0-9]+\\.[0-9]{2}$",
+        "pattern": "^[0-9]+\\.[0-9]{1,4}$",
         "description": "The discount multiplier used when ordering. `0` means no discount and `0.1` means 10% discount. The discount is applied on the price of the order item before any fees are applied.",
         "example": "0.05"
       },


### PR DESCRIPTION
## Problem

The `ProductDiscountMultiplier` schema in `reference/2024-02-05/openapi.json` requires **exactly 2 decimal places** (`^[0-9]+\.[0-9]{2}$`), but the Catalog service returns `discount_multiplier` values with up to **4 decimal places** (e.g. `"0.0000"`). Discounts can legitimately be smaller than `0.01`, so 2 decimals cannot represent them.

This causes the Catalog `sandbox-be-e2e-tests` schema-validation to fail on both the `GET /product` (list) and `GET /product/{product_code}` responses, since both fields `$ref` this one schema.

## Fix

Relax the pattern to permit 1–4 decimal places:

```
- "^[0-9]+\\.[0-9]{2}$"
+ "^[0-9]+\\.[0-9]{1,4}$"
```

This is the "relax the schema" option — preferred over forcing the response to 2 decimals, which would corrupt sub-1% discounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)